### PR TITLE
Bugfix: allows to load a directory from a path that starts with "../"

### DIFF
--- a/surya/input/load.py
+++ b/surya/input/load.py
@@ -44,8 +44,8 @@ def load_from_file(input_path, max_pages=None, start_page=None):
 
 
 def load_from_folder(folder_path, max_pages=None, start_page=None):
-    image_paths = [os.path.join(folder_path, image_name) for image_name in os.listdir(folder_path)]
-    image_paths = [ip for ip in image_paths if not os.path.isdir(ip) and not ip.startswith(".")]
+    image_paths = [os.path.join(folder_path, image_name) for image_name in os.listdir(folder_path) if not image_name.startswith(".")]
+    image_paths = [ip for ip in image_paths if not os.path.isdir(ip)]
 
     images = []
     names = []


### PR DESCRIPTION
Fixed a bug that prevented loading a whole local directory when the path starts with "../"
I suppose the `.startswith(".")` was supposed to skip hidden filenames but it tested for the beginning of the path instead of the beginning of the filename.