### PR TITLE
Truncate repetitions, dump out result as utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The `results.json` file will contain a json dictionary where the keys are the in
   - `bbox` - the axis-aligned rectangle for the text line in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.
 - `languages` - the languages specified for the page
 - `page` - the page number in the file
+- `image_bbox` - the bbox for the image in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.  All line bboxes will be contained within this bbox.
 
 **Performance tips**
 
@@ -130,6 +131,7 @@ The `results.json` file will contain a json dictionary where the keys are the in
 - `horizontal_lines` - horizontal lines detected in the document
   - `bbox` - the axis-aligned line coordinates.
 - `page` - the page number in the file
+- `image_bbox` - the bbox for the image in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.  All line bboxes will be contained within this bbox.
 
 **Performance tips**
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ surya_ocr DATA_PATH --images --langs hi,en
 - `--max` specifies the maximum number of pages to process if you don't want to process everything
 - `--start_page` specifies the page number to start processing from
 
-The `results.json` file will contain these keys for each page of the input document(s):
+The `results.json` file will contain a json dictionary where the keys are the input filenames without extensions.  Each value will be a list of dictionaries, one per page of the input document.  Each page dictionary contains:
 
-- `text_lines` - the detected text in each line
-- `polys` - the polygons for each detected text line in (x1, y1), (x2, y2), (x3, y3), (x4, y4) format.  The points are in clockwise order from the top left.
-- `bboxes` - the axis-aligned rectangles for each detected text line in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.
-- `language` - the languages specified for the page
-- `name` - the name of the file
-- `page_number` - the page number in the file
+- `text_lines` - the detected text and bounding boxes for each line
+  - `text` - the text in the line
+  - `polygon` - the polygon for the text line in (x1, y1), (x2, y2), (x3, y3), (x4, y4) format.  The points are in clockwise order from the top left.
+  - `bbox` - the axis-aligned rectangle for the text line in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.
+- `languages` - the languages specified for the page
+- `page` - the page number in the file
 
 **Performance tips**
 
@@ -120,13 +120,16 @@ surya_detect DATA_PATH --images
 - `--max` specifies the maximum number of pages to process if you don't want to process everything
 - `--results_dir` specifies the directory to save results to instead of the default
 
-The `results.json` file will contain these keys for each page of the input document(s):
+The `results.json` file will contain a json dictionary where the keys are the input filenames without extensions.  Each value will be a list of dictionaries, one per page of the input document.  Each page dictionary contains:
 
-- `polygons` - polygons for each detected text line (these are more accurate than the bboxes) in (x1, y1), (x2, y2), (x3, y3), (x4, y4) format.  The points are in clockwise order from the top left.
-- `bboxes` - axis-aligned rectangles for each detected text line in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.
-- `vertical_lines` - vertical lines detected in the document in (x1, y1, x2, y2) format.
-- `horizontal_lines` - horizontal lines detected in the document in (x1, y1, x2, y2) format.
-- `page_number` - the page number of the document
+- `bboxes` - detected bounding boxes for text
+  - `bbox` - the axis-aligned rectangle for the text line in (x1, y1, x2, y2) format.  (x1, y1) is the top left corner, and (x2, y2) is the bottom right corner.
+  - `polygon` - the polygon for the text line in (x1, y1), (x2, y2), (x3, y3), (x4, y4) format.  The points are in clockwise order from the top left.
+- `vertical_lines` - vertical lines detected in the document
+  - `bbox` - the axis-aligned line coordinates.
+- `horizontal_lines` - horizontal lines detected in the document
+  - `bbox` - the axis-aligned line coordinates.
+- `page` - the page number in the file
 
 **Performance tips**
 
@@ -149,6 +152,7 @@ predictions = batch_detection([image], model, processor)
 # Limitations
 
 - This is specialized for document OCR.  It will likely not work on photos or other images.
+- Surya is for OCR - the goal is to recognize the text lines correctly, not sort them into reading order. Surya will attempt to sort the lines, which will work in many cases, but use something like [marker](https://github.com/VikParuchuri/marker) or other postprocessing if you need to order the text.
 - It is for printed text, not handwriting (though it may work on some handwriting).
 - The model has trained itself to ignore advertisements.
 - You can find language support for OCR in `surya/languages.py`.  Text detection should work with any language.

--- a/benchmark/detection.py
+++ b/benchmark/detection.py
@@ -67,8 +67,8 @@ def main():
 
     page_metrics = collections.OrderedDict()
     for idx, (tb, sb, cb) in enumerate(zip(tess_predictions, predictions, correct_boxes)):
-        surya_boxes = sb["bboxes"]
-        surya_polys = sb["polygons"]
+        surya_boxes = [s.bbox for s in sb.bboxes]
+        surya_polys = [s.polygon for s in sb.bboxes]
 
         surya_metrics = precision_recall(surya_boxes, cb)
         tess_metrics = precision_recall(tb, cb)

--- a/benchmark/recognition.py
+++ b/benchmark/recognition.py
@@ -63,7 +63,8 @@ def main():
     surya_scores = defaultdict(list)
     img_surya_scores = []
     for idx, (pred, ref_text, lang) in enumerate(zip(predictions_by_image, line_text, lang_list)):
-        image_score = overlap_score(pred["text_lines"], ref_text)
+        pred_text = [l.text for l in pred.text_lines]
+        image_score = overlap_score(pred_text, ref_text)
         img_surya_scores.append(image_score)
         for l in lang:
             surya_scores[CODE_TO_LANGUAGE[l]].append(image_score)
@@ -146,7 +147,8 @@ def main():
         for idx, (image, pred, ref_text, bbox, lang) in enumerate(zip(images, predictions_by_image, line_text, bboxes, lang_list)):
             pred_image_name = f"{'_'.join(lang)}_{idx}_pred.png"
             ref_image_name = f"{'_'.join(lang)}_{idx}_ref.png"
-            pred_image = draw_text_on_image(bbox, pred["text_lines"], image.size)
+            pred_text = [l.text for l in pred.text_lines]
+            pred_image = draw_text_on_image(bbox, pred_text, image.size)
             pred_image.save(os.path.join(result_path, pred_image_name))
             ref_image = draw_text_on_image(bbox, ref_text, image.size)
             ref_image.save(os.path.join(result_path, ref_image_name))

--- a/detect_text.py
+++ b/detect_text.py
@@ -62,7 +62,7 @@ def main():
         predictions_by_page[name].append(pred)
 
     with open(os.path.join(result_path, "results.json"), "w+") as f:
-        json.dump(predictions_by_page, f)
+        json.dump(predictions_by_page, f, ensure_ascii=False)
 
     print(f"Wrote results to {result_path}")
 

--- a/detect_text.py
+++ b/detect_text.py
@@ -53,7 +53,7 @@ def main():
                 affinity_map.save(os.path.join(result_path, f"{name}_{idx}_affinity.png"))
 
     predictions_by_page = defaultdict(list)
-    for idx, (pred, name) in enumerate(zip(predictions, names)):
+    for idx, (pred, name, image) in enumerate(zip(predictions, names, images)):
         out_pred = pred.model_dump(exclude=["heatmap", "affinity_map"])
         out_pred["page"] = len(predictions_by_page[name]) + 1
         predictions_by_page[name].append(out_pred)

--- a/detect_text.py
+++ b/detect_text.py
@@ -38,28 +38,25 @@ def main():
 
     if args.images:
         for idx, (image, pred, name) in enumerate(zip(images, predictions, names)):
-            bbox_image = draw_polys_on_image(pred["polygons"], copy.deepcopy(image))
+            polygons = [p.polygon for p in pred.bboxes]
+            bbox_image = draw_polys_on_image(polygons, copy.deepcopy(image))
             bbox_image.save(os.path.join(result_path, f"{name}_{idx}_bbox.png"))
 
-            column_image = draw_lines_on_image(pred["vertical_lines"], copy.deepcopy(image))
+            column_image = draw_lines_on_image(pred.vertical_lines, copy.deepcopy(image))
             column_image.save(os.path.join(result_path, f"{name}_{idx}_column.png"))
 
             if args.debug:
-                heatmap = pred["heatmap"]
+                heatmap = pred.heatmap
                 heatmap.save(os.path.join(result_path, f"{name}_{idx}_heat.png"))
 
-                affinity_map = pred["affinity_map"]
+                affinity_map = pred.affinity_map
                 affinity_map.save(os.path.join(result_path, f"{name}_{idx}_affinity.png"))
-
-    # Remove all the images from the predictions
-    for pred in predictions:
-        pred.pop("heatmap", None)
-        pred.pop("affinity_map", None)
 
     predictions_by_page = defaultdict(list)
     for idx, (pred, name) in enumerate(zip(predictions, names)):
-        pred["page_number"] = len(predictions_by_page[name]) + 1
-        predictions_by_page[name].append(pred)
+        out_pred = pred.model_dump(exclude=["heatmap", "affinity_map"])
+        out_pred["page"] = len(predictions_by_page[name]) + 1
+        predictions_by_page[name].append(out_pred)
 
     with open(os.path.join(result_path, "results.json"), "w+") as f:
         json.dump(predictions_by_page, f, ensure_ascii=False)

--- a/ocr_text.py
+++ b/ocr_text.py
@@ -66,12 +66,10 @@ def main():
             page_image.save(os.path.join(result_path, f"{name}_{idx}_text.png"))
 
     out_preds = defaultdict(list)
-    page_num = defaultdict(int)
-    for i, pred in enumerate(predictions_by_image):
+    for name, pred, image in zip(names, predictions_by_image, images):
         out_pred = pred.model_dump()
-        out_pred["page"] = page_num[names[i]]
-        page_num[names[i]] += 1
-        out_preds[names[i]].append(out_pred)
+        out_pred["page"] = len(out_preds[name]) + 1
+        out_preds[name].append(out_pred)
 
     with open(os.path.join(result_path, "results.json"), "w+") as f:
         json.dump(out_preds, f, ensure_ascii=False)

--- a/ocr_text.py
+++ b/ocr_text.py
@@ -58,19 +58,23 @@ def main():
 
     predictions_by_image = run_ocr(images, image_langs, det_model, det_processor, rec_model, rec_processor)
 
-    page_num = defaultdict(int)
-    for i, pred in enumerate(predictions_by_image):
-        pred["name"] = names[i]
-        pred["page"] = page_num[names[i]]
-        page_num[names[i]] += 1
-
     if args.images:
         for idx, (name, image, pred) in enumerate(zip(names, images, predictions_by_image)):
-            page_image = draw_text_on_image(pred["bboxes"], pred["text_lines"], image.size)
+            bboxes = [l.bbox for l in pred.text_lines]
+            pred_text = [l.text for l in pred.text_lines]
+            page_image = draw_text_on_image(bboxes, pred_text, image.size)
             page_image.save(os.path.join(result_path, f"{name}_{idx}_text.png"))
 
+    out_preds = defaultdict(list)
+    page_num = defaultdict(int)
+    for i, pred in enumerate(predictions_by_image):
+        out_pred = pred.model_dump()
+        out_pred["page"] = page_num[names[i]]
+        page_num[names[i]] += 1
+        out_preds[names[i]].append(out_pred)
+
     with open(os.path.join(result_path, "results.json"), "w+") as f:
-        json.dump(predictions_by_image, f, ensure_ascii=False)
+        json.dump(out_preds, f, ensure_ascii=False)
 
     print(f"Wrote results to {result_path}")
 

--- a/ocr_text.py
+++ b/ocr_text.py
@@ -70,7 +70,7 @@ def main():
             page_image.save(os.path.join(result_path, f"{name}_{idx}_text.png"))
 
     with open(os.path.join(result_path, "results.json"), "w+") as f:
-        json.dump(predictions_by_image, f)
+        json.dump(predictions_by_image, f, ensure_ascii=False)
 
     print(f"Wrote results to {result_path}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "surya-ocr"
-version = "0.2.1"
-description = "Document OCR models for multilingual text detection and recognition"
+version = "0.2.2"
+description = "OCR and line detection in 90+ languages"
 authors = ["Vik Paruchuri <vik.paruchuri@gmail.com>"]
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/surya/detection.py
+++ b/surya/detection.py
@@ -103,8 +103,8 @@ def batch_detection(images: List, model, processor) -> List[DetectionResult]:
             vertical_lines=vertical_lines,
             horizontal_lines=horizontal_lines,
             heatmap=heat_img,
-            affinity_map=aff_img
-
+            affinity_map=aff_img,
+            image_bbox=[0, 0, orig_sizes[i][0], orig_sizes[i][1]]
         )
 
         results.append(result)

--- a/surya/ocr.py
+++ b/surya/ocr.py
@@ -7,6 +7,7 @@ from PIL import Image
 
 from surya.detection import batch_detection
 from surya.input.processing import slice_polys_from_image, slice_bboxes_from_image
+from surya.postprocessing.text import truncate_repetitions
 from surya.recognition import batch_recognition
 
 
@@ -73,6 +74,9 @@ def run_ocr(images: List[Image.Image], langs: List[List[str]], det_model, det_pr
         slice_start = slice_end
 
         assert len(image_lines) == len(det_pred["polygons"]) == len(det_pred["bboxes"])
+
+        # Remove repeated characters
+        image_lines = [truncate_repetitions(l) for l in image_lines]
         predictions_by_image.append({
             "text_lines": image_lines,
             "polys": det_pred["polygons"],

--- a/surya/ocr.py
+++ b/surya/ocr.py
@@ -51,7 +51,8 @@ def run_recognition(images: List[Image.Image], langs: List[List[str]], rec_model
 
         pred = OCRResult(
             text_lines=text_lines,
-            languages=lang
+            languages=lang,
+            image_bbox=[0, 0, image.size[0], image.size[1]]
         )
         predictions_by_image.append(pred)
 
@@ -98,7 +99,8 @@ def run_ocr(images: List[Image.Image], langs: List[List[str]], det_model, det_pr
 
         predictions_by_image.append(OCRResult(
             text_lines=lines,
-            languages=lang
+            languages=lang,
+            image_bbox=det_pred.image_bbox
         ))
 
     return predictions_by_image

--- a/surya/postprocessing/heatmap.py
+++ b/surya/postprocessing/heatmap.py
@@ -10,13 +10,13 @@ from surya.schema import PolygonBox
 from surya.settings import settings
 
 
-def clean_contained_boxes(boxes: List[PolygonBox]):
+def clean_contained_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
     new_boxes = []
     for box_obj in boxes:
         box = box_obj.bbox
         contained = False
         for other_box_obj in boxes:
-            if other_box_obj.corners == box_obj.corners:
+            if other_box_obj.polygon == box_obj.polygon:
                 continue
 
             other_box = other_box_obj.bbox
@@ -118,16 +118,16 @@ def detect_boxes(linemap, text_threshold, low_text):
     return det, labels
 
 
-def get_detected_boxes(textmap, text_threshold=settings.DETECTOR_TEXT_THRESHOLD,  low_text=settings.DETECTOR_BLANK_THRESHOLD):
+def get_detected_boxes(textmap, text_threshold=settings.DETECTOR_TEXT_THRESHOLD,  low_text=settings.DETECTOR_BLANK_THRESHOLD) -> List[PolygonBox]:
     textmap = textmap.copy()
     textmap = textmap.astype(np.float32)
     boxes, labels = detect_boxes(textmap, text_threshold, low_text)
     # From point form to box form
-    boxes = [PolygonBox(corners=box) for box in boxes]
+    boxes = [PolygonBox(polygon=box) for box in boxes]
     return boxes
 
 
-def get_and_clean_boxes(textmap, processor_size, image_size):
+def get_and_clean_boxes(textmap, processor_size, image_size) -> List[PolygonBox]:
     bboxes = get_detected_boxes(textmap)
     for bbox in bboxes:
         bbox.rescale(processor_size, image_size)

--- a/surya/postprocessing/text.py
+++ b/surya/postprocessing/text.py
@@ -5,6 +5,37 @@ from PIL import Image, ImageDraw, ImageFont
 from surya.settings import settings
 
 
+def truncate_repetitions(text: str, min_len=15):
+    # From nougat, with some cleanup
+    if len(text) < 2 * min_len:
+        return text
+
+    # try to find a length at which the tail is repeating
+    max_rep_len = None
+    for rep_len in range(min_len, int(len(text) / 2)):
+        # check if there is a repetition at the end
+        same = True
+        for i in range(0, rep_len):
+            if text[len(text) - rep_len - i - 1] != text[len(text) - i - 1]:
+                same = False
+                break
+
+        if same:
+            max_rep_len = rep_len
+
+    if max_rep_len is None:
+        return text
+
+    lcs = text[-max_rep_len:]
+
+    # remove all but the last repetition
+    text_to_truncate = text
+    while text_to_truncate.endswith(lcs):
+        text_to_truncate = text_to_truncate[:-max_rep_len]
+
+    return text[:len(text_to_truncate)]
+
+
 def get_text_size(text, font):
     im = Image.new(mode="P", size=(0, 0))
     draw = ImageDraw.Draw(im)

--- a/surya/postprocessing/text.py
+++ b/surya/postprocessing/text.py
@@ -1,8 +1,30 @@
 import os
+from typing import List
 
 import requests
 from PIL import Image, ImageDraw, ImageFont
+
+from surya.schema import TextLine
 from surya.settings import settings
+
+
+def sort_text_lines(lines: List[TextLine], tolerance=1.25):
+    # Sorts in reading order.  Not 100% accurate, this should only
+    # be used as a starting point for more advanced sorting.
+    vertical_groups = {}
+    for line in lines:
+        group_key = round(line.bbox[1] / tolerance) * tolerance
+        if group_key not in vertical_groups:
+            vertical_groups[group_key] = []
+        vertical_groups[group_key].append(line)
+
+    # Sort each group horizontally and flatten the groups into a single list
+    sorted_lines = []
+    for _, group in sorted(vertical_groups.items()):
+        sorted_group = sorted(group, key=lambda x: x.bbox[0])
+        sorted_lines.extend(sorted_group)
+
+    return sorted_lines
 
 
 def truncate_repetitions(text: str, min_len=15):

--- a/surya/schema.py
+++ b/surya/schema.py
@@ -99,6 +99,7 @@ class TextLine(PolygonBox):
 class OCRResult(BaseModel):
     text_lines: List[TextLine]
     languages: List[str]
+    image_bbox: List[float]
 
 
 class DetectionResult(BaseModel):
@@ -107,3 +108,4 @@ class DetectionResult(BaseModel):
     horizontal_lines: List[ColumnLine]
     heatmap: Any
     affinity_map: Any
+    image_bbox: List[float]


### PR DESCRIPTION
- Ensure repetitive strings are truncated
- Save results as utf-8 so they look nice when the json is opened in a text editor
- Sort text lines in basic order (will work in many, but not all, cases)
- refactor internal data schema
- Change output format to add more information (documented in README)