### PR TITLE
Fix OCR exception when no text detected

### DIFF
--- a/surya/recognition.py
+++ b/surya/recognition.py
@@ -26,6 +26,9 @@ def batch_recognition(images: List, languages: List[List[str]], model, processor
     assert all([isinstance(image, Image.Image) for image in images])
     assert len(images) == len(languages)
 
+    if len(images) == 0:
+        return [], []
+
     for l in languages:
         assert len(l) <= settings.RECOGNITION_MAX_LANGS, f"OCR only supports up to {settings.RECOGNITION_MAX_LANGS} languages per image, you passed {l}."
 


### PR DESCRIPTION
This is a trivial fix for cases where there is no text detected at all. This is an example that replicates it:
![1_z2](https://github.com/user-attachments/assets/bd4fdf05-5e78-4440-96b6-a8e9476fc5f6)

Running it with:
`surya_ocr cases/1_z2.png --images --langs pt`

Crashed here due to the recognizer being called with no slices
```
  File "/home/mmacvicar/.cache/pypoetry/virtualenvs/surya-ocr-El9qYN6W-py3.11/lib/python3.11/site-packages/transformers/image_utils.py", line 117, in is_batched
    return is_valid_image(img[0])
```

Thanks for the great work.
