### PR TITLE
fix: Use ThreadPoolExecutor if ProcessPoolExecutor failed

### DIFF
--- a/surya/benchmark/metrics.py
+++ b/surya/benchmark/metrics.py
@@ -2,7 +2,7 @@ from functools import partial
 from itertools import repeat
 
 import numpy as np
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 def intersection_area(box1, box2):
     x_left = max(box1[0], box2[0])
@@ -85,10 +85,17 @@ def precision_recall(preds, references, threshold=.5, workers=8, penalize_double
     if penalize_double:
         coverage_func = calculate_coverage
 
-    with ProcessPoolExecutor(max_workers=workers) as executor:
-        precision_func = partial(coverage_func, penalize_double=penalize_double)
-        precision_iou = executor.map(precision_func, preds, repeat(references))
-        reference_iou = executor.map(coverage_func, references, repeat(preds))
+    try:
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            precision_func = partial(coverage_func, penalize_double=penalize_double)
+            precision_iou = executor.map(precision_func, preds, repeat(references))
+            reference_iou = executor.map(coverage_func, references, repeat(preds))
+    except Exception:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            precision_func = partial(coverage_func, penalize_double=penalize_double)
+            precision_iou = executor.map(precision_func, preds, repeat(references))
+            reference_iou = executor.map(coverage_func, references, repeat(preds))
+
 
     precision_classes = [1 if i > threshold else 0 for i in precision_iou]
     precision = sum(precision_classes) / len(precision_classes)

--- a/surya/layout.py
+++ b/surya/layout.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from typing import List, Optional
 from PIL import Image
 import numpy as np
@@ -193,12 +193,21 @@ def batch_layout_detection(images: List, model, processor, detection_results: Op
     else:
         futures = []
         max_workers = min(settings.DETECTOR_POSTPROCESSING_CPU_WORKERS, len(images))
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
-            for i in range(len(images)):
-                future = executor.submit(parallel_get_regions, preds[i], orig_sizes[i], id2label, detection_results[i] if detection_results else None)
-                futures.append(future)
+        try:
+            with ProcessPoolExecutor(max_workers=max_workers) as executor:
+                for i in range(len(images)):
+                    future = executor.submit(parallel_get_regions, preds[i], orig_sizes[i], id2label, detection_results[i] if detection_results else None)
+                    futures.append(future)
 
-            for future in futures:
-                results.append(future.result())
+                for future in futures:
+                    results.append(future.result())
+        except Exception:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                for i in range(len(images)):
+                    future = executor.submit(parallel_get_regions, preds[i], orig_sizes[i], id2label, detection_results[i] if detection_results else None)
+                    futures.append(future)
+
+                for future in futures:
+                    results.append(future.result())
 
     return results


### PR DESCRIPTION
This pull request addresses the same issue as #135.

When this library is run within a multiprocessing library like [Celery](https://github.com/celery/celery), using `ProcessPoolExecutor` can result in the error `daemonic processes are not allowed to have children.`
So if it failed, use `ThreadPoolExecutor` instead.
