### PR TITLE
Fixed issue with box of zero width or height

### DIFF
--- a/surya/postprocessing/heatmap.py
+++ b/surya/postprocessing/heatmap.py
@@ -39,6 +39,11 @@ def keep_largest_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
 def clean_contained_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
     new_boxes = []
     for box_obj in boxes:
+        xs = [point[0] for point in box_obj.polygon]
+        ys = [point[1] for point in box_obj.polygon]
+        if max(xs) == min(xs) or max(ys) == min(ys):
+            continue
+
         box = box_obj.bbox
         contained = False
         for other_box_obj in boxes:

--- a/surya/postprocessing/heatmap.py
+++ b/surya/postprocessing/heatmap.py
@@ -36,7 +36,7 @@ def keep_largest_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
     return new_boxes
 
 
-def clean_contained_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
+def clean_boxes(boxes: List[PolygonBox]) -> List[PolygonBox]:
     new_boxes = []
     for box_obj in boxes:
         xs = [point[0] for point in box_obj.polygon]
@@ -173,7 +173,7 @@ def get_and_clean_boxes(textmap, processor_size, image_size, text_threshold=None
         bbox.rescale(processor_size, image_size)
         bbox.fit_to_bounds([0, 0, image_size[0], image_size[1]])
 
-    bboxes = clean_contained_boxes(bboxes)
+    bboxes = clean_boxes(bboxes)
     return bboxes
 
 


### PR DESCRIPTION
### Issue:
```bash
 File "/Users/dobosevych/Documents/APPS/MLLab/surya/surya/input/processing.py", line 114, in slice_and_pad_poly
    cv2.fillPoly(mask, [np.int32(coordinates)], 1)
cv2.error: OpenCV(4.10.0) :-1: error: (-5:Bad argument) in function 'fillPoly'
> Overload resolution failed:
>  - Layout of the output array img is incompatible with cv::Mat
>  - Expected Ptr<cv::UMat> for argument 'img'
```
The issue was happening when mask had zero height or width, this was by bounding boxes of zero height of width.
### How to reproduce?
```python
from PIL import Image
import surya
from surya.ocr import run_ocr
from surya.model.detection.model import load_model as load_det_model, load_processor as load_det_processor
from surya.model.recognition.model import load_model as load_rec_model
from surya.model.recognition.processor import load_processor as load_rec_processor

image_paths = ["test1229.png"]

images = [Image.open(image_path) for image_path in image_paths]
langs = ["ru"]  # Replace with your languages - optional but recommended
det_processor, det_model = load_det_processor(), load_det_model()
rec_model, rec_processor = load_rec_model(), load_rec_processor()

predictions = run_ocr(images, [langs] * len(images), det_model, det_processor, rec_model, rec_processor)
print(predictions)
```
<img width="245" alt="test1229" src="https://github.com/user-attachments/assets/654b64f0-3d16-4dce-9b4b-392d05ea90a9">

### Solution:
Added additional filtering to support such cases in clean_contained_boxes,  also function renamed to clean_boxes, as not it not only clean contained boxes, but filters zero width boxes.

I have read the CLA Document and I hereby sign the CLA
