### PR TITLE
Switch to ThreadPoolExecutor and misc changes for speedup

### DIFF
--- a/benchmark/detection.py
+++ b/benchmark/detection.py
@@ -55,7 +55,7 @@ def main():
             correct_boxes.append([rescale_bbox(b, (1000, 1000), img_size) for b in boxes])
 
     start = time.time()
-    predictions = batch_text_detection(images, model, processor)
+    predictions = batch_text_detection(images, model, processor, include_heatmap=False, include_affinity_map=False)
     surya_time = time.time() - start
 
     if args.tesseract:

--- a/benchmark/detection.py
+++ b/benchmark/detection.py
@@ -55,7 +55,7 @@ def main():
             correct_boxes.append([rescale_bbox(b, (1000, 1000), img_size) for b in boxes])
 
     start = time.time()
-    predictions = batch_text_detection(images, model, processor, include_maps=False)
+    predictions = batch_text_detection(images, model, processor)
     surya_time = time.time() - start
 
     if args.tesseract:

--- a/benchmark/detection.py
+++ b/benchmark/detection.py
@@ -55,7 +55,7 @@ def main():
             correct_boxes.append([rescale_bbox(b, (1000, 1000), img_size) for b in boxes])
 
     start = time.time()
-    predictions = batch_text_detection(images, model, processor, include_heatmap=False, include_affinity_map=False)
+    predictions = batch_text_detection(images, model, processor, include_maps=False)
     surya_time = time.time() - start
 
     if args.tesseract:

--- a/detect_layout.py
+++ b/detect_layout.py
@@ -39,7 +39,7 @@ def main():
     start = time.time()
     line_predictions = batch_text_detection(images, det_model, det_processor)
 
-    layout_predictions = batch_layout_detection(images, model, processor, line_predictions)
+    layout_predictions = batch_layout_detection(images, model, processor, line_predictions, include_maps=args.debug)
     result_path = os.path.join(args.results_dir, folder_name)
     os.makedirs(result_path, exist_ok=True)
     if args.debug:

--- a/detect_text.py
+++ b/detect_text.py
@@ -35,7 +35,7 @@ def main():
         folder_name = os.path.basename(args.input_path).split(".")[0]
 
     start = time.time()
-    predictions = batch_text_detection(images, model, processor)
+    predictions = batch_text_detection(images, model, processor, include_maps=args.debug)
     result_path = os.path.join(args.results_dir, folder_name)
     os.makedirs(result_path, exist_ok=True)
     end = time.time()

--- a/surya/detection.py
+++ b/surya/detection.py
@@ -107,7 +107,7 @@ def batch_detection(
         yield preds, [orig_sizes[j] for j in batch_image_idxs]
 
 
-def parallel_get_lines(preds, orig_sizes, include_maps=True):
+def parallel_get_lines(preds, orig_sizes, include_maps=False):
     heatmap, affinity_map = preds
     heat_img, aff_img = None, None
     if include_maps:
@@ -128,7 +128,7 @@ def parallel_get_lines(preds, orig_sizes, include_maps=True):
     return result
 
 
-def batch_text_detection(images: List, model, processor, batch_size=None, include_maps=True) -> List[TextDetectionResult]:
+def batch_text_detection(images: List, model, processor, batch_size=None, include_maps=False) -> List[TextDetectionResult]:
     detection_generator = batch_detection(images, model, processor, batch_size=batch_size)
 
     postprocessing_futures = []

--- a/surya/layout.py
+++ b/surya/layout.py
@@ -167,7 +167,7 @@ def get_regions(heatmaps: List[np.ndarray], orig_size, id2label, segment_assignm
     return bboxes
 
 
-def parallel_get_regions(heatmaps: List[np.ndarray], orig_size, id2label, detection_results=None, include_maps=True) -> LayoutResult:
+def parallel_get_regions(heatmaps: List[np.ndarray], orig_size, id2label, detection_results=None, include_maps=False) -> LayoutResult:
     logits = np.stack(heatmaps, axis=0)
     segment_assignment = logits.argmax(axis=0)
     if detection_results is not None:
@@ -190,7 +190,7 @@ def parallel_get_regions(heatmaps: List[np.ndarray], orig_size, id2label, detect
     return result
 
 
-def batch_layout_detection(images: List, model, processor, detection_results: Optional[List[TextDetectionResult]] = None, batch_size=None, include_maps=True) -> List[LayoutResult]:
+def batch_layout_detection(images: List, model, processor, detection_results: Optional[List[TextDetectionResult]] = None, batch_size=None, include_maps=False) -> List[LayoutResult]:
     layout_generator = batch_detection(images, model, processor, batch_size=batch_size)
     id2label = model.config.id2label
 

--- a/surya/layout.py
+++ b/surya/layout.py
@@ -167,7 +167,7 @@ def get_regions(heatmaps: List[np.ndarray], orig_size, id2label, segment_assignm
     return bboxes
 
 
-def parallel_get_regions(heatmaps: List[np.ndarray], orig_size, id2label, detection_results=None, include_heatmaps=True, include_segmentation_map=True) -> LayoutResult:
+def parallel_get_regions(heatmaps: List[np.ndarray], orig_size, id2label, detection_results=None, include_maps=True) -> LayoutResult:
     logits = np.stack(heatmaps, axis=0)
     segment_assignment = logits.argmax(axis=0)
     if detection_results is not None:
@@ -177,20 +177,20 @@ def parallel_get_regions(heatmaps: List[np.ndarray], orig_size, id2label, detect
         bboxes = get_regions(heatmaps, orig_size, id2label, segment_assignment)
 
     segmentation_img = None
-    if include_segmentation_map:
+    if include_maps:
         segmentation_img = Image.fromarray(segment_assignment.astype(np.uint8))
 
     result = LayoutResult(
         bboxes=bboxes,
         segmentation_map=segmentation_img,
-        heatmaps=heatmaps if include_heatmaps else None,
+        heatmaps=heatmaps if include_maps else None,
         image_bbox=[0, 0, orig_size[0], orig_size[1]]
     )
 
     return result
 
 
-def batch_layout_detection(images: List, model, processor, detection_results: Optional[List[TextDetectionResult]] = None, batch_size=None, include_heatmaps=True, include_segmentation_map=True) -> List[LayoutResult]:
+def batch_layout_detection(images: List, model, processor, detection_results: Optional[List[TextDetectionResult]] = None, batch_size=None, include_maps=True) -> List[LayoutResult]:
     layout_generator = batch_detection(images, model, processor, batch_size=batch_size)
     id2label = model.config.id2label
 
@@ -208,8 +208,7 @@ def batch_layout_detection(images: List, model, processor, detection_results: Op
                     orig_size,
                     id2label,
                     detection_results[img_idx] if detection_results else None,
-                    include_heatmaps,
-                    include_segmentation_map
+                    include_maps
                 )
 
                 postprocessing_futures.append(future)

--- a/surya/schema.py
+++ b/surya/schema.py
@@ -171,6 +171,7 @@ class TextDetectionResult(BaseModel):
 class LayoutResult(BaseModel):
     bboxes: List[LayoutBox]
     segmentation_map: Optional[Any]
+    heatmaps: Optional[Any]
     image_bbox: List[float]
 
 

--- a/surya/schema.py
+++ b/surya/schema.py
@@ -163,14 +163,14 @@ class OCRResult(BaseModel):
 class TextDetectionResult(BaseModel):
     bboxes: List[PolygonBox]
     vertical_lines: List[ColumnLine]
-    heatmap: Any
-    affinity_map: Any
+    heatmap: Optional[Any]
+    affinity_map: Optional[Any]
     image_bbox: List[float]
 
 
 class LayoutResult(BaseModel):
     bboxes: List[LayoutBox]
-    segmentation_map: Any
+    segmentation_map: Optional[Any]
     image_bbox: List[float]
 
 

--- a/surya/util/parallel.py
+++ b/surya/util/parallel.py
@@ -1,6 +1,16 @@
-class FakeParallel():
-    def __init__(self, func, *args):
-        self._result = func(*args)
+from concurrent.futures import Future, Executor
 
-    def result(self):
-        return self._result
+class FakeFuture(Future):
+    def __init__(self, func, *args, **kwargs):
+        super().__init__()
+        try:
+            self.set_result(func(*args, **kwargs))
+        except Exception as e:
+            self.set_exception(e)
+
+class FakeExecutor(Executor):
+    def __init__(self, max_workers=None):
+        super().__init__()
+
+    def submit(self, fn, *args, **kwargs):
+        return FakeFuture(fn, *args, **kwargs)

--- a/surya/util/parallel.py
+++ b/surya/util/parallel.py
@@ -1,16 +1,19 @@
-from concurrent.futures import Future, Executor
-
-class FakeFuture(Future):
+class FakeFuture:
     def __init__(self, func, *args, **kwargs):
-        super().__init__()
-        try:
-            self.set_result(func(*args, **kwargs))
-        except Exception as e:
-            self.set_exception(e)
+        self._result = func(*args, **kwargs)
 
-class FakeExecutor(Executor):
-    def __init__(self, max_workers=None):
-        super().__init__()
+    def result(self):
+        return self._result
+
+class FakeExecutor:
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *excinfo):
+        pass
 
     def submit(self, fn, *args, **kwargs):
         return FakeFuture(fn, *args, **kwargs)


### PR DESCRIPTION
- We get a significant speedup from switching to ThreadPoolExecutor.
- Add a FakeExecutor
- Added flags to omit heat maps, affinity maps and segmentation maps. These are not being used by Marker.