### PR TITLE
Fixed image dpi from 96 to 124 for layout detection

### DIFF
--- a/surya/settings.py
+++ b/surya/settings.py
@@ -10,7 +10,7 @@ import os
 class Settings(BaseSettings):
     # General
     TORCH_DEVICE: Optional[str] = None
-    IMAGE_DPI: int = 100 # Used for detection, layout, reading order
+    IMAGE_DPI: int = 124 # Used for detection, layout, reading order
     IMAGE_DPI_HIGHRES: int = 192  # Used for OCR, table rec
     IN_STREAMLIT: bool = False # Whether we're running in streamlit
     ENABLE_EFFICIENT_ATTENTION: bool = True # Usually keep True, but if you get CUDA errors, setting to False can help

--- a/surya/settings.py
+++ b/surya/settings.py
@@ -10,7 +10,7 @@ import os
 class Settings(BaseSettings):
     # General
     TORCH_DEVICE: Optional[str] = None
-    IMAGE_DPI: int = 96 # Used for detection, layout, reading order
+    IMAGE_DPI: int = 100 # Used for detection, layout, reading order
     IMAGE_DPI_HIGHRES: int = 192  # Used for OCR, table rec
     IN_STREAMLIT: bool = False # Whether we're running in streamlit
     ENABLE_EFFICIENT_ATTENTION: bool = True # Usually keep True, but if you get CUDA errors, setting to False can help


### PR DESCRIPTION
I have a few cases where tabled can't recognize table on a page where whole page is a table.

Here is how I tested the DPI number. With default 96 it was not detecting this tables. With 100 it's spotted the table in one case, but still missed in another 2. 

After testing other 2 cases, i found sweet spot 124 DPI.
With 124 DPI it's working for all cases.

Can't upload this cases to this PR for testing, bcs of data protection.

```
def load_pdfs_images(input_path, max_pages=None, start_page=None):
    if os.path.isdir(input_path):
        images, _, _ = load_from_folder(input_path, max_pages, start_page=start_page, dpi=124)
        highres_images, names, text_lines = load_from_folder(input_path, max_pages, dpi=surya_settings.IMAGE_DPI_HIGHRES,
                                                             load_text_lines=True, start_page=start_page)
    else:
        images, _, _ = load_from_file(input_path, max_pages, start_page=start_page, dpi=124)
        highres_images, names, text_lines = load_from_file(input_path, max_pages, dpi=surya_settings.IMAGE_DPI_HIGHRES,
                                                           load_text_lines=True, start_page=start_page)

    return images, highres_images, names, text_lines```