### PR TITLE
Improve typing for `PolygonBox.bbox`

### DIFF
--- a/surya/common/polygon.py
+++ b/surya/common/polygon.py
@@ -47,6 +47,7 @@ class PolygonBox(BaseModel):
         return self.width * self.height
 
     @computed_field
+    @property
     def bbox(self) -> List[float]:
         x_coords = [point[0] for point in self.polygon]
         y_coords = [point[1] for point in self.polygon]


### PR DESCRIPTION
Pydantic recommends that `@computed_field` attributes also be typed with a `@property`, as otherwise the type checker gets confused: https://docs.pydantic.dev/2.0/usage/computed_fields/

> If the computed_field decorator is applied to a bare function (e.g. a function without the @property or @cached_property decorator) it will wrap the function in property itself. Although this is more concise, you will lose IntelliSense in your IDE, and confuse static type checkers, thus explicit use of @property is recommended.