### PR TITLE
Foundation image improvements

### DIFF
--- a/surya/common/surya/__init__.py
+++ b/surya/common/surya/__init__.py
@@ -167,7 +167,6 @@ class SuryaModel(S3DownloaderMixin, PreTrainedModel):
 
         # Special image attention mask during prefill, ignored during decoding
         if self.config.unmask_image and inputs_embeds.shape[1] != 1:
-            print(f'Unmasking image positions')
             if cache_position is None:
                 past_seen_tokens = (
                     past_key_values.get_seq_length() if past_key_values is not None else 0

--- a/surya/common/surya/config.py
+++ b/surya/common/surya/config.py
@@ -25,6 +25,7 @@ class SuryaModelConfig(PretrainedConfig):
         decoder=None,
         tasks: dict | None = None,
         bbox_embed_size: int = 64,
+        unmask_image: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -43,6 +44,7 @@ class SuryaModelConfig(PretrainedConfig):
         self.tasks = tasks
         self.tie_word_embeddings = True
         self.bbox_embed_size = bbox_embed_size
+        self.unmask_image = unmask_image
 
         if isinstance(vision_encoder, dict):
             vision_encoder = SuryaEncoderConfig(

--- a/surya/common/surya/config.py
+++ b/surya/common/surya/config.py
@@ -17,7 +17,8 @@ class SuryaModelConfig(PretrainedConfig):
         eos_token_id=1,
         pad_token_id=2,
         image_token_id=3,
-        special_token_count=4,
+        register_token_id=4,
+        special_token_count=5,
         tile_size=(1024, 256),
         max_sequence_length=1536,
         special_ocr_tokens=None,
@@ -26,6 +27,7 @@ class SuryaModelConfig(PretrainedConfig):
         tasks: dict | None = None,
         bbox_embed_size: int = 64,
         unmask_image: bool = False,
+        num_register_tokens: int = 0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -34,6 +36,7 @@ class SuryaModelConfig(PretrainedConfig):
         self.bbox_size = bbox_size
         self.blank_bbox_token_id = blank_bbox_token_id
         self.image_token_id = image_token_id
+        self.register_token_id = register_token_id
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
@@ -45,6 +48,7 @@ class SuryaModelConfig(PretrainedConfig):
         self.tie_word_embeddings = True
         self.bbox_embed_size = bbox_embed_size
         self.unmask_image = unmask_image
+        self.num_register_tokens = num_register_tokens
 
         if isinstance(vision_encoder, dict):
             vision_encoder = SuryaEncoderConfig(

--- a/surya/common/surya/processor/__init__.py
+++ b/surya/common/surya/processor/__init__.py
@@ -26,6 +26,7 @@ IMAGE_TOKEN = "<IMAGE>"
 PAD_TOKEN = "<PAD>"
 NO_OUTPUT_TOKEN = "<NOP>"
 IMAGE_ROTATED_TOKEN = "<ROT>"
+REGISTER_TOKEN = "<REG>"
 
 # Task specific tokens
 OCR_WITH_BOXES_BOS_TOKEN = "<OCR-WB>"
@@ -44,12 +45,14 @@ class SuryaOCRProcessor(S3DownloaderMixin, ProcessorMixin):
         tile_size: Tuple[int, int],
         image_tokens_per_tile: int,
         blank_bbox_token_id: int,
+        num_register_tokens: int,
         **kwargs,
     ):
         self.image_processor = image_processor
         self.ocr_tokenizer = ocr_tokenizer
         self.tile_size = tile_size
         self.image_tokens_per_tile = image_tokens_per_tile
+        self.num_register_tokens = num_register_tokens
 
         self.tokenizer_vocab_size = 0
         for attr in self.attributes:
@@ -67,6 +70,7 @@ class SuryaOCRProcessor(S3DownloaderMixin, ProcessorMixin):
         self.eoi_token_id = self.special_token_mapping.get(EOI_TOKEN)
         self.no_output_token = self.special_token_mapping.get(NO_OUTPUT_TOKEN)
         self.image_rotated_token = self.special_token_mapping.get(IMAGE_ROTATED_TOKEN)
+        self.register_token_id = self.special_token_mapping.get(REGISTER_TOKEN)
 
         self.bos_token_id = {
             "ocr_with_boxes": self.special_token_mapping.get(OCR_WITH_BOXES_BOS_TOKEN),
@@ -150,6 +154,7 @@ class SuryaOCRProcessor(S3DownloaderMixin, ProcessorMixin):
 
         num_tiles = image_tiles.shape[0]
         input_ids = [self.image_token_id] * num_tiles * self.image_tokens_per_tile
+        input_ids += [self.register_token_id] * self.num_register_tokens
 
         # Handle the image being rotated in the imdataset
         if rotated:

--- a/surya/recognition/loader.py
+++ b/surya/recognition/loader.py
@@ -72,6 +72,7 @@ class RecognitionModelLoader(ModelLoader):
             tile_size=config.tile_size,
             image_tokens_per_tile=config.vision_encoder.num_patches,
             blank_bbox_token_id=config.blank_bbox_token_id,
+            num_register_tokens=config.num_register_tokens,
             sequence_length=None
         )
         config.eos_token_id = processor.eos_token_id


### PR DESCRIPTION
- Add support for unmasking the image during prefill; Use `unmask_image` in the config
- Add register tokens to act as attention sinks - These are also unmasked along with the image; Use `num_register_tokens` in the config