### PR TITLE
Optimize Inference

### DIFF
--- a/surya/common/surya/decoder/__init__.py
+++ b/surya/common/surya/decoder/__init__.py
@@ -168,13 +168,11 @@ class Qwen2Attention(nn.Module):
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         input_shape = hidden_states.shape[:-1]
-        head_dim = self.head_dim
-        hidden_shape_q = (*input_shape, self.config.num_attention_heads, head_dim)
-        hidden_shape_kv = (*input_shape, self.config.num_key_value_heads, head_dim)
+        hidden_shape = (*input_shape, -1, self.head_dim)
 
-        query_states = self.q_proj(hidden_states).view(hidden_shape_q).transpose(1, 2)
-        key_states = self.k_proj(hidden_states).view(hidden_shape_kv).transpose(1, 2)
-        value_states = self.v_proj(hidden_states).view(hidden_shape_kv).transpose(1, 2)
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
         cos, sin = position_embeddings
         query_states, key_states = apply_rotary_pos_emb(

--- a/surya/detection/__init__.py
+++ b/surya/detection/__init__.py
@@ -151,3 +151,5 @@ class DetectionPredictor(BasePredictor):
                     preds[idx] = heatmaps
 
             yield preds, [orig_sizes[j] for j in batch_image_idxs]
+
+        torch.cuda.empty_cache()

--- a/surya/layout/__init__.py
+++ b/surya/layout/__init__.py
@@ -219,5 +219,8 @@ class LayoutPredictor(BasePredictor):
             batch_results = slicer.join(batch_results, tile_positions)
             results.extend(batch_results)
 
+        self.model.decoder.model._clear_cache()
+        torch.cuda.empty_cache()
+
         assert len(results) == len(images)
         return results

--- a/surya/recognition/__init__.py
+++ b/surya/recognition/__init__.py
@@ -572,6 +572,10 @@ class RecognitionPredictor(BasePredictor):
             current_inputs = self.maybe_trim_cache_padding(current_inputs)
             mark_step()
         pbar.close()
+        
+        del self.kv_cache
+        self.kv_cache = None
+        torch.cuda.empty_cache()
 
         return predicted_tokens, batch_bboxes, scores
 

--- a/surya/recognition/__init__.py
+++ b/surya/recognition/__init__.py
@@ -75,7 +75,7 @@ class RecognitionPrompt:
 class RecognitionPredictor(BasePredictor):
     model_loader_cls = RecognitionModelLoader
     batch_size = settings.RECOGNITION_BATCH_SIZE
-    torch_dtype = settings.MODEL_DTYPE_BFLOAT
+    torch_dtype = None      # No default, loader picks the dtype based on device properties - bf16/fp16
     default_batch_sizes = {"cpu": 32, "mps": 64, "cuda": 256, "xla": 128}
     encoder_chunk_size: int = 4096
     encoder_chunk_sizes = {"cpu": 4096, "mps": 4096, "cuda": 32768, "xla": 32768}

--- a/surya/recognition/loader.py
+++ b/surya/recognition/loader.py
@@ -43,7 +43,6 @@ class RecognitionModelLoader(ModelLoader):
             self.checkpoint, torch_dtype=dtype, config=config
         ).to(device)
         model = model.eval()
-        model.decoder.merge_kv()
 
         logger.debug(
             f"Loaded recognition model {self.checkpoint} from {SuryaModel.get_local_path(self.checkpoint)} onto device {model.device} with dtype {dtype}, using decoder attention mechanism {model.config.decoder._attn_implementation}, encoder attention mechanism {model.config.vision_encoder._attn_implementation}."

--- a/surya/recognition/loader.py
+++ b/surya/recognition/loader.py
@@ -8,11 +8,11 @@ from surya.common.surya.config import SuryaModelConfig
 from surya.common.surya import SuryaModel
 from surya.common.surya.processor import SuryaOCRProcessor
 from surya.common.surya.processor.tokenizer import SuryaOCRTokenizer
+from surya.common.util import is_flash_attn_2_supported
 from surya.logging import get_logger
 from surya.settings import settings
 
 logger = get_logger()
-
 
 class RecognitionModelLoader(ModelLoader):
     def __init__(self, checkpoint: Optional[str] = None):
@@ -22,17 +22,20 @@ class RecognitionModelLoader(ModelLoader):
             self.checkpoint = settings.RECOGNITION_MODEL_CHECKPOINT
 
     def model(
-        self, device=settings.TORCH_DEVICE_MODEL, dtype=settings.MODEL_DTYPE_BFLOAT
+        self, device=settings.TORCH_DEVICE_MODEL, dtype=None,
     ) -> SuryaModel:
         if device is None:
             device = settings.TORCH_DEVICE_MODEL
         if dtype is None:
-            dtype = settings.MODEL_DTYPE_BFLOAT
+            if torch.cuda.is_bf16_supported():
+                dtype = settings.MODEL_DTYPE_BFLOAT
+            else:
+                dtype = settings.MODEL_DTYPE
 
         torch.set_float32_matmul_precision("high")
         config = SuryaModelConfig.from_pretrained(self.checkpoint)
 
-        if is_flash_attn_2_available():
+        if is_flash_attn_2_available() and is_flash_attn_2_supported():
             config.decoder._attn_implementation = "flash_attention_2"
             config.vision_encoder._attn_implementation = "flash_attention_2"
         else:

--- a/surya/recognition/loader.py
+++ b/surya/recognition/loader.py
@@ -43,6 +43,7 @@ class RecognitionModelLoader(ModelLoader):
             self.checkpoint, torch_dtype=dtype, config=config
         ).to(device)
         model = model.eval()
+        model.decoder.merge_kv()
 
         logger.debug(
             f"Loaded recognition model {self.checkpoint} from {SuryaModel.get_local_path(self.checkpoint)} onto device {model.device} with dtype {dtype}, using decoder attention mechanism {model.config.decoder._attn_implementation}, encoder attention mechanism {model.config.vision_encoder._attn_implementation}."

--- a/surya/recognition/loader.py
+++ b/surya/recognition/loader.py
@@ -27,7 +27,9 @@ class RecognitionModelLoader(ModelLoader):
         if device is None:
             device = settings.TORCH_DEVICE_MODEL
         if dtype is None:
-            if torch.cuda.is_bf16_supported():
+            # See https://github.com/pytorch/pytorch/issues/118122 - T4 (device version 7.5) will return true since it supports
+            # emulated bf16, but falls back to very slow kernels, especially for SDPA
+            if torch.cuda.is_bf16_supported(including_emulation=False):
                 dtype = settings.MODEL_DTYPE_BFLOAT
             else:
                 dtype = settings.MODEL_DTYPE


### PR DESCRIPTION
- [x] Bring down peak memory usage:
  - Clear KV caches in layout and recognition model loops
  - Clear CUDA cache in the detection model
- [x] Speed up recognition model inference
  - Slight speed up by merging KV projection in decoder
- [x] Fix support on older GPUs - Choose the right dtype and FA2/SDPA
- [x] Patch SDPA attention for foundation encoder
  - Attention needs to be unrolled into separate batch elements, instead of a single call with attention masking when using SDPA 