### PR TITLE
fix: Prevent crash when no table rows are detected

### DIFF
--- a/surya/table_rec/__init__.py
+++ b/surya/table_rec/__init__.py
@@ -217,6 +217,20 @@ class TableRecPredictor(BasePredictor):
                         })
 
             # Re-inference to predict cells
+            if not row_encoder_hidden_states:
+                # Return empty results if no rows were detected in any image in the batch.
+                for orig_size in orig_sizes:
+                    output_order.append(
+                        TableResult(
+                            cells=[],
+                            unmerged_cells=[],
+                            rows=[],
+                            cols=[],
+                            image_bbox=[0, 0, orig_size[0], orig_size[1]],
+                        )
+                    )
+                continue # Move to next batch
+
             row_encoder_hidden_states = torch.stack(row_encoder_hidden_states)
             row_inputs = self.processor(images=None, query_items=row_query_items, columns=columns, convert_images=False)
             row_input_ids = row_inputs["input_ids"]


### PR DESCRIPTION
This PR fixes a `RuntimeError: stack expects a non-empty TensorList` that occurs in the `TableRecPredictor` when processing a table image where the model fails to detect any rows.

**Problem:**
When no rows are found, the `row_encoder_hidden_states` list remains empty. The subsequent call to `torch.stack()` on this empty list causes the application to crash.

**Solution:**
This change introduces a check to verify if `row_encoder_hidden_states` is empty before calling `torch.stack()`. If it is, the code now gracefully handles this edge case by creating an empty `TableResult` for the image and continuing to the next batch.