### PR TITLE
fix: preserve full filename stems for multi-dot inputs and correct debug image naming

### DIFF
--- a/surya/input/load.py
+++ b/surya/input/load.py
@@ -1,4 +1,5 @@
 from typing import List
+from pathlib import Path
 import PIL
 
 from surya.input.processing import open_pdf, get_page_images
@@ -13,7 +14,7 @@ logger = get_logger()
 
 
 def get_name_from_path(path):
-    return os.path.basename(path).split(".")[0]
+    return Path(path).stem
 
 
 def load_pdf(pdf_path, page_range: List[int] | None = None, dpi=settings.IMAGE_DPI):

--- a/surya/scripts/config.py
+++ b/surya/scripts/config.py
@@ -1,4 +1,5 @@
 from typing import List
+from pathlib import Path
 
 import click
 import os
@@ -21,11 +22,31 @@ class CLILoader:
 
     @staticmethod
     def common_options(fn):
-        fn = click.argument("input_path", type=click.Path(exists=True), required=True)(fn)
-        fn = click.option("--output_dir", type=click.Path(exists=False), required=False, default=os.path.join(settings.RESULT_DIR, "surya"), help="Directory to save output.")(fn)
-        fn = click.option("--page_range", type=str, default=None, help="Page range to convert, specify comma separated page numbers or ranges.  Example: 0,5-10,20")(fn)
-        fn = click.option("--images", is_flag=True, help="Save images of detected bboxes.", default=False)(fn)
-        fn = click.option('--debug', '-d', is_flag=True, help='Enable debug mode.', default=False)(fn)
+        fn = click.argument("input_path", type=click.Path(exists=True), required=True)(
+            fn
+        )
+        fn = click.option(
+            "--output_dir",
+            type=click.Path(exists=False),
+            required=False,
+            default=os.path.join(settings.RESULT_DIR, "surya"),
+            help="Directory to save output.",
+        )(fn)
+        fn = click.option(
+            "--page_range",
+            type=str,
+            default=None,
+            help="Page range to convert, specify comma separated page numbers or ranges.  Example: 0,5-10,20",
+        )(fn)
+        fn = click.option(
+            "--images",
+            is_flag=True,
+            help="Save images of detected bboxes.",
+            default=False,
+        )(fn)
+        fn = click.option(
+            "--debug", "-d", is_flag=True, help="Enable debug mode.", default=False
+        )(fn)
         return fn
 
     def load(self, highres: bool = False):
@@ -34,13 +55,16 @@ class CLILoader:
             images, names = load_from_folder(self.filepath, self.page_range)
             folder_name = os.path.basename(self.filepath)
             if highres:
-                highres_images, _ = load_from_folder(self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES)
+                highres_images, _ = load_from_folder(
+                    self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES
+                )
         else:
             images, names = load_from_file(self.filepath, self.page_range)
-            folder_name = os.path.basename(self.filepath).split(".")[0]
+            folder_name = Path(self.filepath).stem
             if highres:
-                highres_images, _ = load_from_file(self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES)
-
+                highres_images, _ = load_from_file(
+                    self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES
+                )
 
         self.images = images
         self.highres_images = highres_images
@@ -59,5 +83,7 @@ class CLILoader:
                 page_lst += list(range(int(start), int(end) + 1))
             else:
                 page_lst.append(int(i))
-        page_lst = sorted(list(set(page_lst)))  # Deduplicate page numbers and sort in order
+        page_lst = sorted(
+            list(set(page_lst))
+        )  # Deduplicate page numbers and sort in order
         return page_lst

--- a/surya/scripts/config.py
+++ b/surya/scripts/config.py
@@ -22,31 +22,11 @@ class CLILoader:
 
     @staticmethod
     def common_options(fn):
-        fn = click.argument("input_path", type=click.Path(exists=True), required=True)(
-            fn
-        )
-        fn = click.option(
-            "--output_dir",
-            type=click.Path(exists=False),
-            required=False,
-            default=os.path.join(settings.RESULT_DIR, "surya"),
-            help="Directory to save output.",
-        )(fn)
-        fn = click.option(
-            "--page_range",
-            type=str,
-            default=None,
-            help="Page range to convert, specify comma separated page numbers or ranges.  Example: 0,5-10,20",
-        )(fn)
-        fn = click.option(
-            "--images",
-            is_flag=True,
-            help="Save images of detected bboxes.",
-            default=False,
-        )(fn)
-        fn = click.option(
-            "--debug", "-d", is_flag=True, help="Enable debug mode.", default=False
-        )(fn)
+        fn = click.argument("input_path", type=click.Path(exists=True), required=True)(fn)
+        fn = click.option("--output_dir", type=click.Path(exists=False), required=False, default=os.path.join(settings.RESULT_DIR, "surya"), help="Directory to save output.")(fn)
+        fn = click.option("--page_range", type=str, default=None, help="Page range to convert, specify comma separated page numbers or ranges.  Example: 0,5-10,20")(fn)
+        fn = click.option("--images", is_flag=True, help="Save images of detected bboxes.", default=False)(fn)
+        fn = click.option('--debug', '-d', is_flag=True, help='Enable debug mode.', default=False)(fn)
         return fn
 
     def load(self, highres: bool = False):
@@ -55,16 +35,13 @@ class CLILoader:
             images, names = load_from_folder(self.filepath, self.page_range)
             folder_name = os.path.basename(self.filepath)
             if highres:
-                highres_images, _ = load_from_folder(
-                    self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES
-                )
+                highres_images, _ = load_from_folder(self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES)
         else:
             images, names = load_from_file(self.filepath, self.page_range)
             folder_name = Path(self.filepath).stem
             if highres:
-                highres_images, _ = load_from_file(
-                    self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES
-                )
+                highres_images, _ = load_from_file(self.filepath, self.page_range, settings.IMAGE_DPI_HIGHRES)
+
 
         self.images = images
         self.highres_images = highres_images
@@ -83,7 +60,5 @@ class CLILoader:
                 page_lst += list(range(int(start), int(end) + 1))
             else:
                 page_lst.append(int(i))
-        page_lst = sorted(
-            list(set(page_lst))
-        )  # Deduplicate page numbers and sort in order
+        page_lst = sorted(list(set(page_lst)))  # Deduplicate page numbers and sort in order
         return page_lst

--- a/surya/scripts/table_recognition.py
+++ b/surya/scripts/table_recognition.py
@@ -28,7 +28,9 @@ logger = get_logger()
 def table_recognition_cli(input_path: str, skip_table_detection: bool, **kwargs):
     loader = CLILoader(input_path, kwargs, highres=True)
 
-    foundation_predictor = FoundationPredictor(checkpoint=settings.LAYOUT_MODEL_CHECKPOINT)
+    foundation_predictor = FoundationPredictor(
+        checkpoint=settings.LAYOUT_MODEL_CHECKPOINT
+    )
     layout_predictor = LayoutPredictor(foundation_predictor)
     table_rec_predictor = TableRecPredictor()
 
@@ -114,7 +116,8 @@ def table_recognition_cli(input_path: str, skip_table_detection: bool, **kwargs)
             )
             rc_image.save(
                 os.path.join(
-                    loader.result_path, f"{name}_page{pnum + 1}_table{table_idx}_rc.png"
+                    loader.result_path,
+                    f"{orig_name}_page{pnum + 1}_table{table_idx}_rc.png",
                 )
             )
 
@@ -123,7 +126,7 @@ def table_recognition_cli(input_path: str, skip_table_detection: bool, **kwargs)
             cell_image.save(
                 os.path.join(
                     loader.result_path,
-                    f"{name}_page{pnum + 1}_table{table_idx}_cells.png",
+                    f"{orig_name}_page{pnum + 1}_table{table_idx}_cells.png",
                 )
             )
 

--- a/tests/test_filename_stems.py
+++ b/tests/test_filename_stems.py
@@ -1,0 +1,80 @@
+import importlib
+import shutil
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def load_input_module(monkeypatch):
+    fake_pil = types.ModuleType("PIL")
+    fake_pil.UnidentifiedImageError = type("UnidentifiedImageError", (Exception,), {})
+
+    fake_image_module = types.ModuleType("PIL.Image")
+    fake_image_module.open = MagicMock()
+    fake_pil.Image = fake_image_module
+
+    fake_processing = types.ModuleType("surya.input.processing")
+    fake_processing.open_pdf = MagicMock()
+    fake_processing.get_page_images = MagicMock()
+
+    fake_settings = types.ModuleType("surya.settings")
+    fake_settings.settings = SimpleNamespace(IMAGE_DPI=96)
+
+    fake_logging = types.ModuleType("surya.logging")
+    fake_logging.get_logger = lambda: MagicMock()
+
+    fake_filetype = types.ModuleType("filetype")
+    fake_filetype.guess = MagicMock(return_value=None)
+
+    monkeypatch.setitem(sys.modules, "PIL", fake_pil)
+    monkeypatch.setitem(sys.modules, "PIL.Image", fake_image_module)
+    monkeypatch.setitem(sys.modules, "surya.input.processing", fake_processing)
+    monkeypatch.setitem(sys.modules, "surya.settings", fake_settings)
+    monkeypatch.setitem(sys.modules, "surya.logging", fake_logging)
+    monkeypatch.setitem(sys.modules, "filetype", fake_filetype)
+    monkeypatch.delitem(sys.modules, "surya.input.load", raising=False)
+
+    return importlib.import_module("surya.input.load")
+
+
+def load_config_module(monkeypatch):
+    fake_load = types.ModuleType("surya.input.load")
+    fake_load.load_from_file = lambda filepath, page_range, dpi=96: (
+        [object()],
+        ["paper.v1"],
+    )
+    fake_load.load_from_folder = lambda filepath, page_range, dpi=96: ([], [])
+
+    fake_settings = types.ModuleType("surya.settings")
+    fake_settings.settings = SimpleNamespace(
+        RESULT_DIR="results", IMAGE_DPI_HIGHRES=192
+    )
+
+    monkeypatch.setitem(sys.modules, "surya.input.load", fake_load)
+    monkeypatch.setitem(sys.modules, "surya.settings", fake_settings)
+    monkeypatch.delitem(sys.modules, "surya.scripts.config", raising=False)
+
+    return importlib.import_module("surya.scripts.config")
+
+
+def test_get_name_from_path_preserves_multi_dot_stem(monkeypatch):
+    load = load_input_module(monkeypatch)
+
+    assert load.get_name_from_path("C:/tmp/paper.v1.pdf") == "paper.v1"
+
+
+def test_cli_loader_result_path_preserves_multi_dot_stem(monkeypatch):
+    config = load_config_module(monkeypatch)
+    output_dir = Path(__file__).with_name("_tmp_results")
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    try:
+        loader = config.CLILoader("paper.v1.pdf", {"output_dir": str(output_dir)})
+        assert Path(loader.result_path).name == "paper.v1"
+    finally:
+        if output_dir.exists():
+            shutil.rmtree(output_dir)


### PR DESCRIPTION
Fixes #496

## Problem

Two related filename handling bugs cause distinct input files to collide in results:

### 1. Multi-dot filenames merge into the same result key

`get_name_from_path()` uses `os.path.basename(path).split(".")[0]`, which truncates everything after the **first** dot. `paper.v1.pdf` and `paper.v2.pdf` both become `paper`, causing their results to merge under one key in `results.json`.

The same truncation in `CLILoader` means different dotted filenames write to the same output directory.

### 2. Table-recognition debug images saved under wrong document name

In `table_recognition.py`, debug image save paths use `name` (a leaked loop variable retaining the **last** document name) instead of `orig_name` (the correct per-prediction source name).

## Fix

- `get_name_from_path()`: `.split(".")[0]` → `Path(path).stem`
- `CLILoader`: same fix for `folder_name`
- `table_recognition.py`: `name` → `orig_name` in both `rc_image.save()` and `cell_image.save()` paths

## Tests

- `test_get_name_from_path_preserves_multi_dot_stem`: verifies `paper.v1.pdf` → `paper.v1`
- `test_cli_loader_result_path_preserves_multi_dot_stem`: verifies CLILoader output path uses full stem

_This fix was developed with AI assistance and reviewed by a human._