### PR TITLE
make it work with transformers 5

### DIFF
--- a/surya/common/adetr/decoder.py
+++ b/surya/common/adetr/decoder.py
@@ -611,7 +611,7 @@ class SuryaADETRDecoderPreTrainedModel(SuryaPreTrainedModel):
     def _tie_weights(self):
         pass
 
-    def tie_weights(self):
+    def tie_weights(self, *, missing_keys=None, recompute_mapping=True):
         pass
 
 

--- a/surya/common/surya/__init__.py
+++ b/surya/common/surya/__init__.py
@@ -165,7 +165,7 @@ class SuryaModel(S3DownloaderMixin, SuryaPreTrainedModel):
                 ]
             )
 
-    def tie_weights(self):
+    def tie_weights(self, *, missing_keys=None, recompute_mapping=True):
         self._tie_weights()
 
     def _tie_weights(self):

--- a/surya/common/surya/__init__.py
+++ b/surya/common/surya/__init__.py
@@ -105,6 +105,11 @@ class SuryaModel(S3DownloaderMixin, SuryaPreTrainedModel):
     _supports_attention_backend = True
     main_input_name = "input_ids"
     _tied_weights_keys = ["lm_head.weight"]
+    # fix: AttributeError: 'SuryaModel' object has no attribute 'all_tied_weights_keys'
+    all_tied_weights_keys = {
+        "lm_head.weight": "model.embed_tokens.weight",
+        # "lm_head.weight": "embed_tokens.weight",
+    }
 
     def __init__(
         self,

--- a/surya/common/surya/__init__.py
+++ b/surya/common/surya/__init__.py
@@ -104,10 +104,14 @@ class SuryaModel(S3DownloaderMixin, SuryaPreTrainedModel):
     _supports_static_cache = True
     _supports_attention_backend = True
     main_input_name = "input_ids"
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = [
+        # fix: SuryaModel LOAD REPORT: Status: MISSING
+        # "lm_head.weight"
+    ]
     # fix: AttributeError: 'SuryaModel' object has no attribute 'all_tied_weights_keys'
     all_tied_weights_keys = {
-        "lm_head.weight": "model.embed_tokens.weight",
+        # fix: SuryaModel LOAD REPORT: Status: MISSING
+        # "lm_head.weight": "model.embed_tokens.weight",
         # "lm_head.weight": "embed_tokens.weight",
     }
 

--- a/surya/common/surya/__init__.py
+++ b/surya/common/surya/__init__.py
@@ -166,11 +166,8 @@ class SuryaModel(S3DownloaderMixin, SuryaPreTrainedModel):
             )
 
     def tie_weights(self, *, missing_keys=None, recompute_mapping=True):
-        self._tie_weights()
-
-    def _tie_weights(self):
-        # Tie weights of lm head and token embedder
-        self._tie_or_clone_weights(self.lm_head, self.embedder.token_embed)
+        # this is handled by all_tied_weights_keys
+        pass
 
     def get_output_embeddings(self) -> nn.Module:
         return self.lm_head

--- a/surya/common/surya/decoder/__init__.py
+++ b/surya/common/surya/decoder/__init__.py
@@ -337,6 +337,7 @@ class Qwen2RotaryEmbedding(nn.Module):
             self.rope_type = config.rope_scaling.get(
                 "rope_type", config.rope_scaling.get("type")
             )
+            # TODO move up?
             # fix: KeyError: 'default'
             # FIXME why config.rope_scaling["rope_type"] == "default"
             # blame rope_config_validation?
@@ -348,11 +349,14 @@ class Qwen2RotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
+
+    def _init_rope(self, device):
         self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
 
         # if self.config.rope_parameters["rope_type"] == "default":
         #     self.config.rope_parameters["rope_type"] = "linear"
 
+        # TODO move up?
         # fix: KeyError: 'factor'
         if not "factor" in self.config.rope_parameters:
             self.config.rope_parameters["factor"] = 1.0
@@ -386,9 +390,19 @@ class Qwen2RotaryEmbedding(nn.Module):
             self.original_inv_freq = self.original_inv_freq.to(device)
             self.register_buffer("inv_freq", self.original_inv_freq, persistent=False)
             self.max_seq_len_cached = self.original_max_seq_len
+            print("surya/common/surya/decoder/__init__.py 390 self.register_buffer inv_freq")
 
     @torch.no_grad()
     def forward(self, x, position_ids):
+        # lazy init
+        # fix: RuntimeError: Tensor on device meta is not on the expected device cpu!
+        if (
+            not hasattr(self, "inv_freq")
+            or self.inv_freq is None
+            or self.inv_freq.device.type == "meta"
+        ):
+            self._init_rope(device=x.device)
+
         if "dynamic" in self.rope_type:
             self._dynamic_frequency_update(position_ids, device=x.device)
 

--- a/surya/common/surya/decoder/__init__.py
+++ b/surya/common/surya/decoder/__init__.py
@@ -337,13 +337,21 @@ class Qwen2RotaryEmbedding(nn.Module):
             self.rope_type = config.rope_scaling.get(
                 "rope_type", config.rope_scaling.get("type")
             )
+            # fix: KeyError: 'default'
+            # FIXME why config.rope_scaling["rope_type"] == "default"
+            # blame rope_config_validation?
+            if self.rope_type == "default":
+                self.rope_type = "linear"
         else:
-            self.rope_type = "default"
+            self.rope_type = "linear"
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
         self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        # if self.config.rope_parameters["rope_type"] == "default":
+        #     self.config.rope_parameters["rope_type"] = "linear"
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)

--- a/surya/common/surya/decoder/__init__.py
+++ b/surya/common/surya/decoder/__init__.py
@@ -353,6 +353,10 @@ class Qwen2RotaryEmbedding(nn.Module):
         # if self.config.rope_parameters["rope_type"] == "default":
         #     self.config.rope_parameters["rope_type"] = "linear"
 
+        # fix: KeyError: 'factor'
+        if not "factor" in self.config.rope_parameters:
+            self.config.rope_parameters["factor"] = 1.0
+
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.original_inv_freq = self.inv_freq

--- a/surya/common/surya/decoder/config.py
+++ b/surya/common/surya/decoder/config.py
@@ -45,6 +45,7 @@ class SuryaDecoderConfig(PretrainedConfig):
         sliding_window=4096,
         max_window_layers=28,
         attention_dropout=0.0,
+        pad_token_id=0,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -71,6 +72,7 @@ class SuryaDecoderConfig(PretrainedConfig):
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
         self.attention_dropout = attention_dropout
+        self.pad_token_id = pad_token_id
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, move it to 'rope_type'.
         if self.rope_scaling is not None and "type" in self.rope_scaling:

--- a/surya/common/surya/encoder/__init__.py
+++ b/surya/common/surya/encoder/__init__.py
@@ -77,14 +77,36 @@ class Qwen2_5_VisionPatchEmbed(nn.Module):
 class Qwen2_5_VisionRotaryEmbedding(nn.Module):
     def __init__(self, dim: int, theta: float = 10000.0) -> None:
         super().__init__()
-        self.inv_freq = 1.0 / (
-            theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim)
+        self.dim = dim
+        self.theta = theta
+
+    def _init_inv_freq(self, device):
+        inv_freq = 1.0 / (
+            self.theta ** (
+                torch.arange(0, self.dim, 2, device=device, dtype=torch.float32)
+                / self.dim
+            )
         )
+        # self.register_buffer("inv_freq", inv_freq, persistent=False)
+        # this tensor is: small, not trained, not saved, recomputable
+        # avoid PyTorch bookkeeping
+        self.inv_freq = inv_freq
 
     def forward(self, seqlen: int) -> torch.Tensor:
-        seq = torch.arange(seqlen, device="cpu", dtype=self.inv_freq.dtype)
-        freqs = torch.outer(seq, self.inv_freq)
-        return freqs
+        # fix: RuntimeError: Tensor on device meta is not on the expected device cpu!
+        # meta-safe lazy init
+        if not hasattr(self, "inv_freq") or self.inv_freq.device.type == "meta":
+            # pick a real device (CPU is fine here)
+            device = torch.device("cpu")
+            self._init_inv_freq(device)
+
+        seq = torch.arange(
+            seqlen,
+            device=self.inv_freq.device,
+            dtype=self.inv_freq.dtype
+        )
+
+        return torch.outer(seq, self.inv_freq)
 
 
 class Qwen2RMSNorm(nn.Module):

--- a/surya/detection/__init__.py
+++ b/surya/detection/__init__.py
@@ -22,7 +22,14 @@ from surya.detection.heatmap import parallel_get_boxes
 class DetectionPredictor(BasePredictor):
     model_loader_cls = DetectionModelLoader
     batch_size = settings.DETECTOR_BATCH_SIZE
-    default_batch_sizes = {"cpu": 8, "mps": 8, "cuda": 36, "xla": 18}
+    # default_batch_sizes = {"cpu": 8, "mps": 8, "cuda": 36, "xla": 18}
+    # FIXME expose CLI parameter
+    # FIXME guess cuda batch_size from VRAM size
+    # also consider thumbnail size (1200x1200?)
+    # 20 -> torch.OutOfMemoryError: CUDA out of memory.
+    # 13 -> RuntimeError: Tensor on device meta is not on the expected device cpu!
+    # 12 -> ok
+    default_batch_sizes = {"cpu": 8, "mps": 8, "cuda": 12, "xla": 18}
 
     def __call__(
         self, images: List[Image.Image], batch_size=None, include_maps=False

--- a/surya/foundation/loader.py
+++ b/surya/foundation/loader.py
@@ -84,7 +84,7 @@ class FoundationModelLoader(ModelLoader):
 
         model = model_cls.from_pretrained(
             self.checkpoint, dtype=dtype, config=config, ignore_mismatched_sizes=True
-        ).to(device)
+        )
         model = model.eval()
 
         if settings.COMPILE_ALL or settings.COMPILE_FOUNDATION:

--- a/surya/foundation/loader.py
+++ b/surya/foundation/loader.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 from transformers.utils import is_flash_attn_2_available
+# from transformers import BitsAndBytesConfig
 
 from surya.common.load import ModelLoader
 from surya.common.surya.config import SuryaModelConfig
@@ -65,6 +66,21 @@ class FoundationModelLoader(ModelLoader):
         config._attn_implementation_autoset = True
         config.vision_encoder._attn_implementation_autoset = True
         config.decoder._attn_implementation_autoset = True
+
+        # no. 8-bit / 4-bit quantization is not compatible with Surya's pipeline
+        # # kwarg for model_cls.from_pretrained
+        # quantization_config = None
+        # if 1:
+        #     # reduce precision and memory usage
+        #     quantization_config = BitsAndBytesConfig(
+        #         load_in_8bit=True,
+        #     )
+        # if 0:
+        #     # reduce precision and memory usage even more
+        #     quantization_config = BitsAndBytesConfig(
+        #         load_in_4bit=True,
+        #         bnb_4bit_compute_dtype=torch.float16
+        #     )
 
         model = model_cls.from_pretrained(
             self.checkpoint, dtype=dtype, config=config, ignore_mismatched_sizes=True

--- a/surya/table_rec/model/decoder.py
+++ b/surya/table_rec/model/decoder.py
@@ -75,6 +75,7 @@ class LabelEmbedding(nn.Module):
 
 class SuryaTableRecDecoder(SuryaADETRDecoderPreTrainedModel):
     _tied_weights_keys = None
+    all_tied_weights_keys = {}
 
     def __init__(self, config, **kwargs):
         super().__init__(config)


### PR DESCRIPTION
fix #484 

all patches were generated by chatGPT

with these patches, the errors are gone
but the OCR function seems broken...

hopefully someone with more insight into the surya codebase
(and with more experience with pytorch)
can fix the patches

i have tried to run
`surya_ocr test-images/ --output_dir test-images-ocr/`
but the output json file contains only garbage

the model load report always says that `lm_head.weight` is missing
how bad is this?

```
SuryaModel LOAD REPORT
Key            | Status  | 
---------------+---------+-
lm_head.weight | MISSING | 
```
