### PR TITLE
Allow Pillow 11 and 12 (relax pillow<11 to pillow<13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pydantic>=2.5.3,<3",
     "pydantic-settings>=2.1.0,<3",
     "python-dotenv>=1.0.0,<2",
-    "pillow>=10.2.0,<11",
+    "pillow>=10.2.0,<13",
     "pypdfium2==4.30.0",
     "filetype>=1.2.0,<2",
     "click>=8.1.8,<9",


### PR DESCRIPTION
## What

Relax the Pillow upper bound: `pillow>=10.2.0,<11` → `pillow>=10.2.0,<13` (admits Pillow 11 and 12).

## Why

The `<11` ceiling looks precautionary rather than code-driven. surya already uses the modern Pillow API throughout — `Image.Resampling.LANCZOS`/`BILINEAR`, `resize`/`thumbnail`, `ImageDraw`, `ImageFont.truetype`, `ImageOps` — and none of the APIs removed in Pillow 10/11 (`Image.ANTIALIAS`, `ImageDraw.textsize`, `ImageFont.getsize`, …). A tree-wide grep for the removed/changed-in-11 symbols found no uses.

This also unblocks downstream consumers (e.g. marker-pdf) whose security updates are gated by surya-ocr's transitive `pillow<11` pin. Refs #464.

## Testing

Full test suite passes with **Pillow 12.2.0** on both transformers 4.57.6 and 5.12.0 (Python 3.11, CPU): `test_detection`, `test_layout`, `test_recognition`, `test_table_rec`, `test_ocr_errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)