### PR TITLE
Support transformers 5.x and huggingface-hub 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "opencv-python-headless==4.11.0.86",
     "openai>=1.55.0,<2",
     "httpx>=0.27.0,<0.28",
-    "huggingface-hub>=0.26.0,<1",
+    "huggingface-hub>=0.26.0,<2",
+    "requests>=2.0.0,<3",
     "filelock>=3.16.0,<4",
     "beautifulsoup4>=4.12.0,<5",
 ]

--- a/surya/common/s3.py
+++ b/surya/common/s3.py
@@ -179,4 +179,47 @@ class S3DownloaderMixin:
                     )
                     raise e  # Reraise exception after max retries
 
-        return super().from_pretrained(local_path, *args, **kwargs)
+        result = super().from_pretrained(local_path, *args, **kwargs)
+        cls._materialize_weights_if_needed(result, local_path)
+        return result
+
+    @staticmethod
+    def _materialize_weights_if_needed(result, local_path: str) -> None:
+        """Repair transformers >= 5.0's silent weight-load failure on
+        surya's custom (vendored) model classes.
+
+        transformers 5.x's mandatory meta-device from_pretrained path
+        silently fails to materialize checkpoint weights into these
+        models -- it reports a clean load (no missing/unexpected keys,
+        no error) while leaving every parameter at its random init,
+        which collapses model outputs (e.g. the OCR-error DistilBert and
+        the EfficientViT text detector). Loading the local single-file
+        safetensors checkpoint directly materializes them correctly
+        (verified bit-exact).
+
+        Scoped narrowly so nothing else changes:
+          - transformers < 5: no-op (4.x already loads weights eagerly),
+            so 4.x behavior is byte-for-byte unchanged.
+          - non-nn.Module results: no-op, so the config / tokenizer /
+            processor classes that also use this mixin are untouched.
+          - sharded or non-safetensors checkpoints: no-op (no local
+            model.safetensors to reload from).
+        Best-effort: never raises; a failed repair just logs.
+        """
+        try:
+            import transformers
+
+            if int(transformers.__version__.split(".")[0]) < 5:
+                return
+            import torch
+
+            if not isinstance(result, torch.nn.Module):
+                return
+            weights_file = os.path.join(local_path, "model.safetensors")
+            if not os.path.exists(weights_file):
+                return
+            from safetensors.torch import load_file
+
+            result.load_state_dict(load_file(weights_file), strict=False)
+        except Exception as e:  # noqa: BLE001 -- never break loading on repair
+            logger.warning(f"weight re-materialization skipped: {e}")

--- a/surya/ocr_error/model/config.py
+++ b/surya/ocr_error/model/config.py
@@ -2,7 +2,16 @@ from collections import OrderedDict
 from typing import Mapping
 
 from transformers.configuration_utils import PretrainedConfig
-from transformers.onnx import OnnxConfig
+
+try:
+    from transformers.onnx import OnnxConfig
+except ImportError:
+    # transformers >= 5.0 removed the built-in ONNX exporter (the
+    # transformers.onnx package; export now lives in the `optimum`
+    # package). DistilBertOnnxConfig below is an ONNX-export helper that
+    # surya's torch inference path never uses, so when the exporter is
+    # absent we skip defining it rather than fail the whole import.
+    OnnxConfig = None
 
 from surya.common.s3 import S3DownloaderMixin
 
@@ -53,16 +62,18 @@ class DistilBertConfig(S3DownloaderMixin, PretrainedConfig):
         super().__init__(**kwargs, pad_token_id=pad_token_id)
 
 
-class DistilBertOnnxConfig(OnnxConfig):
-    @property
-    def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        if self.task == "multiple-choice":
-            dynamic_axis = {0: "batch", 1: "choice", 2: "sequence"}
-        else:
-            dynamic_axis = {0: "batch", 1: "sequence"}
-        return OrderedDict(
-            [
-                ("input_ids", dynamic_axis),
-                ("attention_mask", dynamic_axis),
-            ]
-        )
+if OnnxConfig is not None:
+
+    class DistilBertOnnxConfig(OnnxConfig):
+        @property
+        def inputs(self) -> Mapping[str, Mapping[int, str]]:
+            if self.task == "multiple-choice":
+                dynamic_axis = {0: "batch", 1: "choice", 2: "sequence"}
+            else:
+                dynamic_axis = {0: "batch", 1: "sequence"}
+            return OrderedDict(
+                [
+                    ("input_ids", dynamic_axis),
+                    ("attention_mask", dynamic_axis),
+                ]
+            )

--- a/surya/ocr_error/model/encoder.py
+++ b/surya/ocr_error/model/encoder.py
@@ -10,10 +10,30 @@ from torch.nn import functional as F, MSELoss, CrossEntropyLoss, BCEWithLogitsLo
 from transformers import apply_chunking_to_forward
 from transformers.activations import get_activation
 from transformers.modeling_outputs import BaseModelOutput, SequenceClassifierOutput
-from transformers.pytorch_utils import (
-    find_pruneable_heads_and_indices,
-    prune_linear_layer,
-)
+from transformers.pytorch_utils import prune_linear_layer
+
+try:
+    from transformers.pytorch_utils import find_pruneable_heads_and_indices
+except ImportError:
+    # transformers >= 5.0 removed this helper from pytorch_utils
+    # (https://github.com/datalab-to/surya/issues/492). Vendor the
+    # historical implementation so head pruning keeps working under 5.x.
+    # It is only invoked if MultiHeadSelfAttention.prune_heads() is called
+    # -- which surya inference never does -- but the import must resolve
+    # for this module (and therefore the OCR-error model) to load at all.
+    from typing import List, Set
+
+    def find_pruneable_heads_and_indices(
+        heads: List[int], n_heads: int, head_size: int, already_pruned_heads: Set[int]
+    ):
+        mask = torch.ones(n_heads, head_size)
+        heads = set(heads) - already_pruned_heads
+        for head in heads:
+            head = head - sum(1 if h < head else 0 for h in already_pruned_heads)
+            mask[head] = 0
+        mask = mask.view(-1).contiguous().eq(1)
+        index = torch.arange(len(mask))[mask].long()
+        return heads, index
 
 from transformers.utils import (
     is_flash_attn_greater_or_equal_2_10,
@@ -87,18 +107,19 @@ class Embeddings(nn.Module):
 
         seq_length = input_embeds.size(1)
 
-        # Setting the position-ids to the registered buffer in constructor, it helps
-        # when tracing the model without passing position-ids, solves
-        # isues similar to issue #5664
-        if hasattr(self, "position_ids"):
-            position_ids = self.position_ids[:, :seq_length]
-        else:
-            position_ids = torch.arange(
-                seq_length, dtype=torch.long, device=input_ids.device
-            )  # (max_seq_length)
-            position_ids = position_ids.unsqueeze(0).expand_as(
-                input_ids
-            )  # (bs, max_seq_length)
+        # Compute position ids dynamically rather than reading the
+        # `position_ids` buffer registered in __init__. That buffer is
+        # registered persistent=False, so it is absent from the checkpoint;
+        # under transformers >= 5.0's meta-device fast init the __init__
+        # torch.arange never materializes and the buffer is left as
+        # uninitialized memory -> out-of-range indices into
+        # position_embeddings. Deriving from arange here is equivalent to
+        # the correctly-initialized buffer ([0..seq_length-1]) and works on
+        # both transformers 4.x and 5.x. (The old fallback branch also
+        # referenced input_ids.device when input_ids may be None.)
+        position_ids = torch.arange(
+            seq_length, dtype=torch.long, device=input_embeds.device
+        ).unsqueeze(0)  # (1, seq_length); broadcasts across the batch
 
         position_embeddings = self.position_embeddings(
             position_ids
@@ -736,6 +757,28 @@ class DistilBertModel(DistilBertPreTrainedModel):
         """
         for layer, heads in heads_to_prune.items():
             self.transformer.layer[layer].attention.prune_heads(heads)
+
+    def get_head_mask(self, head_mask, num_hidden_layers, is_attention_chunked=False):
+        # transformers >= 5.0 removed ModuleUtilsMixin.get_head_mask (and
+        # _convert_head_mask_to_5d). Vendor the upstream implementation so
+        # the forward pass works on both 4.x and 5.x. At inference
+        # head_mask is None, so this returns [None] * num_hidden_layers;
+        # the conversion branch preserves behavior if a real head_mask is
+        # ever supplied.
+        if head_mask is not None:
+            if head_mask.dim() == 1:
+                head_mask = (
+                    head_mask.unsqueeze(0).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+                )
+                head_mask = head_mask.expand(num_hidden_layers, -1, -1, -1, -1)
+            elif head_mask.dim() == 2:
+                head_mask = head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1)
+            head_mask = head_mask.to(dtype=self.dtype)
+            if is_attention_chunked is True:
+                head_mask = head_mask.unsqueeze(-1)
+        else:
+            head_mask = [None] * num_hidden_layers
+        return head_mask
 
     def forward(
         self,

--- a/surya/ocr_error/tokenizer.py
+++ b/surya/ocr_error/tokenizer.py
@@ -3,12 +3,34 @@ import os
 import unicodedata
 from typing import List, Optional, Tuple
 
-from transformers.tokenization_utils import (
-    PreTrainedTokenizer,
-    _is_control,
-    _is_punctuation,
-    _is_whitespace,
-)
+from transformers.tokenization_utils import PreTrainedTokenizer
+
+try:
+    from transformers.tokenization_utils import (
+        _is_control,
+        _is_punctuation,
+        _is_whitespace,
+    )
+except ImportError:
+    # transformers >= 5.0 removed these private BERT char-classification
+    # helpers from transformers.tokenization_utils. Vendor the upstream
+    # implementations (unchanged Unicode-category logic) so the basic
+    # tokenizer keeps identical behavior under transformers 5.x.
+    def _is_whitespace(char):
+        if char in (" ", "\t", "\n", "\r"):
+            return True
+        return unicodedata.category(char) == "Zs"
+
+    def _is_control(char):
+        if char in ("\t", "\n", "\r"):
+            return False
+        return unicodedata.category(char).startswith("C")
+
+    def _is_punctuation(char):
+        cp = ord(char)
+        if (33 <= cp <= 47) or (58 <= cp <= 64) or (91 <= cp <= 96) or (123 <= cp <= 126):
+            return True
+        return unicodedata.category(char).startswith("P")
 
 from surya.common.s3 import S3DownloaderMixin
 


### PR DESCRIPTION
## What

Make surya-ocr work under **transformers 5.x** (and the **huggingface-hub 1.x** it pulls in). Fixes #492. Supersedes #487, which patched `surya/common/donut/encoder.py` — a file that no longer exists on `master`.

surya declares `transformers>=4.56.1` with no upper bound, so fresh installs already resolve transformers 5.x and break; CI stays green only because `uv sync --frozen` pins transformers 4.57 in `uv.lock`.

## Changes

transformers 5.x removed several symbols surya imports. Each is guarded with `try/except ImportError`, so **transformers 4.x behavior is unchanged**:

- `pytorch_utils.find_pruneable_heads_and_indices` → vendored polyfill (`ocr_error/model/encoder.py`)
- `transformers.onnx` (built-in ONNX exporter, moved to `optimum`) → guarded import; the export-only `DistilBertOnnxConfig` is skipped when unavailable (`ocr_error/model/config.py`)
- `tokenization_utils._is_control` / `_is_punctuation` / `_is_whitespace` → vendored (`ocr_error/tokenizer.py`)
- `ModuleUtilsMixin.get_head_mask` → vendored onto `DistilBertModel` (`ocr_error/model/encoder.py`)
- `Embeddings` position ids: derived from `arange` in `forward` instead of the `persistent=False` `position_ids` buffer. Under 5.x's meta-device init that buffer is never materialized (and isn't in the checkpoint), giving out-of-range indices into `position_embeddings`.

**Silent weight-load failure** (`common/s3.py`): under transformers 5.x, `from_pretrained`'s meta-device path does not materialize checkpoint weights into these custom model classes — it reports a clean load (no missing/unexpected keys, no error) while leaving every parameter at its random init, which collapses model output. `S3DownloaderMixin` now re-materializes weights from the local single-file `model.safetensors` after `from_pretrained`, scoped to `transformers>=5` and to `nn.Module` results (so 4.x and the config/tokenizer/processor classes are untouched). This affected the OCR-error DistilBert and the EfficientViT detector; stock `transformers.DistilBertForSequenceClassification` loads the same checkpoint fine under 5.x, so this is specific to the vendored classes' interaction with the 5.x loader.

Dependencies:
- `huggingface-hub`: `<1` → `<2` (transformers 5.x requires hub ≥ 1.3)
- `requests`: added as a direct dependency (imported in `common/s3.py` and `debug/fonts.py`; previously satisfied transitively via huggingface-hub 0.x, which hub 1.x dropped)

## Testing

Full test suite passes on **both transformers 5.12.0 and 4.57.6** (Python 3.11, Pillow 12.2.0, CPU): `test_ocr_errors`, `test_detection`, `test_layout`, `test_recognition`, `test_table_rec`. The VLM-backed suites ran against a local `llama-server` (llama.cpp) backend.

Note: I did **not** touch `uv.lock`, so CI (`uv sync --frozen`) still exercises transformers 4.57. Happy to regenerate the lockfile onto transformers 5.x in this PR, or leave that as a separate step — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)