### PR TITLE
Merge contained fast-layout blocks; declare requests dependency

### DIFF
--- a/MODEL_LICENSE
+++ b/MODEL_LICENSE
@@ -53,7 +53,7 @@ As conditions to the Licenses set forth in this Agreement, You agree not to use,
 (a) In any way that violates any applicable national, federal, state, local or international law or regulation; or
 (b) to directly or indirectly infringe or misappropriate any third party intellectual property rights (including those of Licensor or any Contributor)
 2. Commercial:
-(a) for any purpose if You (your employer, or the entity you are affiliated with) generated more than two million US Dollars ($5,000,000) in gross revenue in the prior year, except where Your Use is limited to personal use or research purposes;
-(b) for any purpose if You (your employer, or the entity you are affiliated with) has raised more than two million US dollars ($5,000,000) in total equity or debt funding from any source, except where Your Use is limited to personal use or research purposes; or
+(a) for any purpose if You (your employer, or the entity you are affiliated with) generated more than five million US Dollars ($5,000,000) in gross revenue in the prior year, except where Your Use is limited to personal use or research purposes;
+(b) for any purpose if You (your employer, or the entity you are affiliated with) has raised more than five million US dollars ($5,000,000) in total equity or debt funding from any source, except where Your Use is limited to personal use or research purposes; or
 (c)  for any purpose if You (your employer, or the entity you are affiliated with) provides or otherwise makes available any product or service that competes with any product or service offered by or made available by Licensor or any of its affiliates.
 Commercial and broader use licenses may be available from Licensor at the following URL: https://www.datalab.to/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "surya-ocr"
-version = "0.22.0"
+version = "0.22.1"
 description = "OCR, layout, reading order, and table recognition in 90+ languages."
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -27,6 +27,7 @@ dependencies = [
     "huggingface-hub>=1.5.0,<2",
     "filelock>=3.16.0,<4",
     "beautifulsoup4>=4.12.0,<5",
+    "requests>=2.28.0,<3",
 ]
 
 [project.urls]

--- a/surya/fast_layout/__init__.py
+++ b/surya/fast_layout/__init__.py
@@ -30,6 +30,47 @@ def _poly(b):
     return [[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
 
 
+def _merge_contained_boxes(boxes: List[LayoutBox], threshold: float) -> List[LayoutBox]:
+    """Drop same-label boxes that are (near-)contained in a larger same-label box.
+
+    rf-detr sometimes emits a big block plus smaller duplicate/fragment blocks of
+    the same type inside it (e.g. a Text column plus Text fragments). For each box,
+    if at least `threshold` of its area lies within a larger box of the *same*
+    label, the smaller is removed and its extent merged into the larger (the larger
+    grows to their union, so any sliver poking out is preserved). Restricted to the
+    same label so a distinct element that merely falls within another's bbox (e.g. a
+    PageHeader inside a page-spanning Text box) is kept. `threshold` > 1 disables it.
+    """
+    if threshold > 1 or len(boxes) < 2:
+        return boxes
+    # Largest first, so smaller boxes get absorbed into the bigger survivor.
+    survivors: List[LayoutBox] = []
+    for b in sorted(boxes, key=lambda x: x.area, reverse=True):
+        absorbed = False
+        for s in survivors:
+            if s.label != b.label:
+                continue
+            if b.area > 0 and s.intersection_area(b) / b.area >= threshold:
+                sb, bb = s.bbox, b.bbox
+                s.polygon = _poly(
+                    [
+                        min(sb[0], bb[0]),
+                        min(sb[1], bb[1]),
+                        max(sb[2], bb[2]),
+                        max(sb[3], bb[3]),
+                    ]
+                )
+                absorbed = True
+                break
+        if not absorbed:
+            survivors.append(b)
+    # Re-number reading order contiguously over the survivors.
+    survivors.sort(key=lambda x: x.position)
+    for rank, b in enumerate(survivors):
+        b.position = rank
+    return survivors
+
+
 def build_layout_result(image: Image.Image, dets, order) -> LayoutResult:
     """Turn one page's raw rf-detr detections into an ordered LayoutResult.
 
@@ -78,6 +119,7 @@ def build_layout_result(image: Image.Image, dets, order) -> LayoutResult:
                 confidence=d["score"],
             )
         )
+    boxes = _merge_contained_boxes(boxes, settings.FAST_LAYOUT_CONTAINMENT_THRESHOLD)
     boxes.sort(key=lambda b: b.position)
     return LayoutResult(
         bboxes=boxes,

--- a/surya/settings.py
+++ b/surya/settings.py
@@ -153,6 +153,11 @@ class Settings(BaseSettings):
     FAST_LAYOUT_MODEL_CHECKPOINT: str = "hf://datalab-to/surya_layout2"
     FAST_LAYOUT_BATCH_SIZE: Optional[int] = None
     FAST_LAYOUT_CONFIDENCE_THRESHOLD: float = 0.4
+    # Post-process: if a same-label block is contained within (or overlaps almost
+    # entirely with) a larger same-label block, drop the smaller and merge its
+    # extent into the larger. This is the fraction of the smaller box that must lie
+    # inside the larger to trigger the merge. Set to >1 to disable.
+    FAST_LAYOUT_CONTAINMENT_THRESHOLD: float = 0.9
     FAST_ORDER_MODEL_CHECKPOINT: str = "hf://datalab-to/surya_layout2/order"
     # Run the learned reading-order head after fast layout. When False, boxes come
     # back in raster order (top-to-bottom, left-to-right) and the order model is

--- a/tests/test_fast_layout_server.py
+++ b/tests/test_fast_layout_server.py
@@ -74,3 +74,50 @@ def test_continuous_batching_coalesces(engine, test_image, monkeypatch):
 
     assert sum(sizes) == 6
     assert max(sizes) > 1  # at least some pages coalesced into one forward
+
+
+def _box(label, x0, y0, x1, y1, pos=0):
+    from surya.layout.schema import LayoutBox
+
+    return LayoutBox(
+        polygon=[[x0, y0], [x1, y0], [x1, y1], [x0, y1]],
+        label=label,
+        raw_label=label,
+        position=pos,
+        confidence=0.5,
+    )
+
+
+def test_merge_contained_same_label():
+    """A same-label box fully inside a larger one is dropped (no model needed)."""
+    from surya.fast_layout import _merge_contained_boxes
+
+    big = _box("Text", 0, 0, 100, 100, pos=0)
+    inner = _box("Text", 10, 10, 40, 40, pos=1)
+    out = _merge_contained_boxes([big, inner], 0.9)
+    assert len(out) == 1
+    assert out[0].bbox == [0, 0, 100, 100]
+    assert out[0].position == 0  # renumbered contiguously
+
+
+def test_merge_keeps_cross_label():
+    """A different-label box inside another is kept (e.g. PageHeader in Text)."""
+    from surya.fast_layout import _merge_contained_boxes
+
+    text = _box("Text", 0, 0, 100, 100, pos=0)
+    header = _box("PageHeader", 10, 10, 40, 40, pos=1)
+    out = _merge_contained_boxes([text, header], 0.9)
+    assert len(out) == 2
+    assert {b.label for b in out} == {"Text", "PageHeader"}
+
+
+def test_merge_expands_to_union_on_near_overlap():
+    """A same-label box that mostly overlaps but pokes out extends the survivor."""
+    from surya.fast_layout import _merge_contained_boxes
+
+    big = _box("Text", 0, 0, 100, 100)
+    # 90% inside, pokes out to x=110
+    poke = _box("Text", 50, 50, 110, 60)
+    out = _merge_contained_boxes([big, poke], 0.5)
+    assert len(out) == 1
+    assert out[0].bbox[2] == 110  # survivor grew to the union

--- a/uv.lock
+++ b/uv.lock
@@ -3999,7 +3999,7 @@ wheels = [
 
 [[package]]
 name = "surya-ocr"
-version = "0.21.2"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -4016,6 +4016,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pypdfium2" },
     { name = "python-dotenv" },
+    { name = "requests" },
     { name = "torch" },
     { name = "torchvision" },
     { name = "transformers" },
@@ -4050,6 +4051,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.1.0,<3" },
     { name = "pypdfium2", specifier = ">=5.10.1,<6" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2" },
+    { name = "requests", specifier = ">=2.28.0,<3" },
     { name = "torch", specifier = ">=2.7.0,<3" },
     { name = "torchvision", specifier = ">=0.20.0,<1" },
     { name = "transformers", specifier = ">=5.12.1" },


### PR DESCRIPTION
- fast_layout: drop smaller same-label boxes (near-)contained in a larger one and merge extent into the survivor, controlled by FAST_LAYOUT_CONTAINMENT_THRESHOLD (default 0.9). Fixes duplicate/fragment detections (e.g. four_in_one.pdf pages 2-3) while keeping cross-label elements like a PageHeader inside a Text block.
- declare requests in dependencies (imported directly by common/s3.py and debug/fonts.py; ocr_error/detection s3 checkpoint download needs it).
- bump to 0.22.1 and sync uv.lock.