### PR TITLE
fix: migrate doc.render() to page.render() for pypdfium2 5.x compatibility

### DIFF
--- a/surya/scripts/streamlit_app.py
+++ b/surya/scripts/streamlit_app.py
@@ -284,12 +284,9 @@ def open_pdf(pdf_file):
 @st.cache_data()
 def get_page_image(pdf_file, page_num, dpi=settings.IMAGE_DPI):
     doc = open_pdf(pdf_file)
-    renderer = doc.render(
-        pypdfium2.PdfBitmap.to_pil,
-        page_indices=[page_num - 1],
-        scale=dpi / 72,
-    )
-    png = list(renderer)[0]
+    page = doc.get_page(page_num - 1)
+    bitmap = page.render(scale=dpi / 72)
+    png = bitmap.to_pil()
     png_image = png.convert("RGB")
     doc.close()
     return png_image


### PR DESCRIPTION
The `doc.render()` method was removed from PdfDocument in pypdfium2 4.0.
The code uses the old API which no longer works with the declared
dependency range (>=5.10.1,<6).

Changed `get_page_image()` to use `page.render()` instead of `doc.render()`,
which is the correct API for pypdfium2 5.x.

Fixes the `AttributeError: 'PdfDocument' object has no attribute 'render'`
crash when loading PDFs in the Streamlit app.