### PR TITLE
Fix guided-JSON layout/table schemas for llamacpp backend (unsupported \d escape in grammar)

### DIFF
--- a/surya/inference/prompts.py
+++ b/surya/inference/prompts.py
@@ -127,7 +127,7 @@ LAYOUT_JSON_SCHEMA = {
             "label": {"type": "string", "enum": LAYOUT_LABEL_SET},
             "bbox": {
                 "type": "string",
-                "pattern": r"^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$",
+                "pattern": r"^[0-9]{1,4} [0-9]{1,4} [0-9]{1,4} [0-9]{1,4}$",
             },
             "count": {"type": "integer", "minimum": 0, "maximum": 10000},
         },
@@ -149,7 +149,7 @@ TABLE_REC_JSON_SCHEMA = {
             "label": {"type": "string", "enum": TABLE_REC_LABEL_SET},
             "bbox": {
                 "type": "string",
-                "pattern": r"^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$",
+                "pattern": r"^[0-9]{1,4} [0-9]{1,4} [0-9]{1,4} [0-9]{1,4}$",
             },
         },
         "required": ["label", "bbox"],


### PR DESCRIPTION
## Bug

`LAYOUT_JSON_SCHEMA` and `TABLE_REC_JSON_SCHEMA` in `surya/inference/prompts.py` use a bbox `"pattern"` of `r"^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$"`.

When `SURYA_INFERENCE_BACKEND=llamacpp` (the documented Docker-free local inference path) with guided JSON enabled, this schema is converted to a GBNF grammar by `llama-server` for constrained decoding. `llama-server`'s json-schema-to-grammar converter fails to parse the `\d` escape:

```
parse: error parsing grammar: unknown escape at \d"{1,4} " ...
failed to parse grammar
srv    send_error: task id = 0, error: Failed to initialize samplers: failed to parse grammar
srv  process_sing: failed to launch slot with task, id_task = 0
```

Every layout/table-rec request against the llamacpp backend hits this, so every request errors. `LayoutPredictor.__call__` (`surya/layout/__init__.py`) sees `out.error` and returns an empty `LayoutResult(error=True)` with no logged detail on *why*; `marker`'s `LayoutBuilder` (`marker/builders/layout.py`) then logs only `"Layout inference failed for page N; leaving page empty."`

Reproduced on a 58-page real-world PDF via `marker --mode balanced`: 57-58 of 58 pages came back with empty layout, despite the underlying OCR/recognition model producing correct output when called directly (a separate, valid schema).

## Fix

Swap `\d` for the explicit character class `[0-9]`. Semantically identical for this pattern (digits only), and the more portable form across JSON-Schema-to-grammar implementations.

## Verification

Patched `surya/inference/prompts.py` in an installed `surya-ocr==0.22.1` env and re-ran the same 58-page document via `marker --mode balanced` with the llamacpp backend:

- Before: `Layout inference failed` logged for 57-58/58 pages
- After: 0 failures, correct LaTeX equation output, correct section-header detection

## Possibly worth doing separately

Might also be worth having `LayoutPredictor` log `out.error`'s underlying detail (or at least the raw server response) instead of silently swallowing it into `error=True` - this cost real time to root-cause since nothing surfaced the actual grammar-parse failure above the "leaving page empty" warning. Happy to open that as a separate PR if useful; kept this one scoped to the actual bug.